### PR TITLE
MCR nerf revert

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
@@ -1,3 +1,5 @@
+// FLUFFY FRONTIER EDIT NOTE: ДАННЫЙ ФАЙЛ БЫЛ ЧАСТИЧНО ПОДВЕРГНУТ ПЕРЕЗАПИСИ ПО ПУТИ tff_modular\modules\mcr_nerf_revert\code\mcr_override.dm! В СЛУЧАЕ ВОЗМОЖНЫХ ОШИБОК ВЫЗВАННЫХ ИЗМЕНЕНИЯМИ ТУТ - СМОТРИТЕ ФАЙЛ С ПЕРЕЗАПИСЯМИ.
+
 /*
 MICROFUSION CELL SYSTEM
 

--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -1,3 +1,5 @@
+// FLUFFY FRONTIER EDIT NOTE: ДАННЫЙ ФАЙЛ БЫЛ ЧАСТИЧНО ПОДВЕРГНУТ ПЕРЕЗАПИСИ ПО ПУТИ tff_modular\modules\mcr_nerf_revert\code\mcr_override.dm! В СЛУЧАЕ ВОЗМОЖНЫХ ОШИБОК ВЫЗВАННЫХ ИЗМЕНЕНИЯМИ ТУТ - СМОТРИТЕ ФАЙЛ С ПЕРЕЗАПИСЯМИ.
+
 #define DUALWIELD_PENALTY_EXTRA_MULTIPLIER 1.4
 
 // Master file for cell loadable energy guns. PROCS ONLY YOU MONKEYS!

--- a/tff_modular/modules/mcr_nerf_revert/code/mcr_override.dm
+++ b/tff_modular/modules/mcr_nerf_revert/code/mcr_override.dm
@@ -1,0 +1,35 @@
+// MCR
+
+/obj/item/gun/microfusion/insert_cell(mob/user, obj/item/stock_parts/cell/microfusion/inserting_cell, display_message = TRUE)
+	var/hotswap = FALSE
+	if(cell)
+		hotswap = TRUE
+	var/obj/item/stock_parts/cell/old_cell = cell
+	if(display_message)
+		balloon_alert(user, "cell inserted")
+	if(hotswap)
+		eject_cell(user, FALSE, FALSE)
+	if(sound_cell_insert)
+		playsound(src, sound_cell_insert, sound_cell_insert_volume, sound_cell_insert_vary)
+	cell = inserting_cell
+	inserting_cell.forceMove(src)
+	inserting_cell.inserted_into_weapon()
+	cell.parent_gun = src
+	if(old_cell)
+		user.put_in_hands(old_cell)
+	recharge_newshot()
+	update_appearance()
+	return TRUE
+
+// MCR CELL
+
+/obj/item/stock_parts/cell/microfusion
+	empty = FALSE
+	chargerate = 300
+
+/obj/item/stock_parts/cell/microfusion/inserted_into_weapon()
+	do_sparks(4, FALSE, src)
+
+/obj/item/stock_parts/cell/microfusion/cell_removal_discharge()
+	do_sparks(4, FALSE, src)
+	update_appearance()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7079,6 +7079,7 @@
 #include "tff_modular\modules\clothing\suit\suit.dm"
 #include "tff_modular\modules\discord\discord.dm"
 #include "tff_modular\modules\hair\code\hair.dm"
+#include "tff_modular\modules\mcr_nerf_revert\code\mcr_override.dm"
 #include "tff_modular\modules\modular_automapper\automapper.dm"
 #include "tff_modular\modules\redsec\code\vending.dm"
 #include "tff_modular\modules\smites\femboyfication.dm"


### PR DESCRIPTION
## О Pull Request

Данный ПР восстанавливает "валидное" и пригодное состояние МКРов, позволяя перезаряжать их.

## Как это может улучшит/повлиять на игровой процесс/ролевую игру

МКР больше не будут игрушкой которая валяется в арсенале до момента тотальной прокачки или покупки речарджер аттачмента.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

![dreamseeker_CFSFfOjNJ4](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/82096ff4-125a-45aa-9a47-dcf173812465)
  
</details>

## Changelog

:cl:
balance: MCR now can be reloaded normally again!
/:cl:
