### PR TITLE
[NON-MODULAR] EVENTMAKER QOL

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -265,8 +265,8 @@ GLOBAL_PROTECT(admin_verbs_debug)
 
 	/*FLUFFY FRONTIER ADDITION BEGIN - EVENTMAKER QOL*/
 	/datum/admins/proc/delay,
-	/datum/admins/proc/delay_round_end,
 	/datum/admins/proc/end_round,
+	/client/proc/adminchangemap,
 	/*FLUFFY FRONTIER EDIT END*/
 	)
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, GLOBAL_PROC_REF(release)))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -262,6 +262,12 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/reload_interactions,	/*SKYRAT EDIT ADDITION*/
 	/client/proc/test_area_spawner,		/*AUTOMAPPER - SKYRAT EDIT ADDITION*/
 	/client/proc/toggle_liquid_debug,	/*SKYRAT EDIT ADDITION*/
+
+	/*FLUFFY FRONTIER ADDITION BEGIN - EVENTMAKER QOL*/
+	/datum/admins/proc/delay,
+	/datum/admins/proc/delay_round_end,
+	/datum/admins/proc/end_round,
+	/*FLUFFY FRONTIER EDIT END*/
 	)
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, GLOBAL_PROC_REF(release)))
 GLOBAL_PROTECT(admin_verbs_possess)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -263,11 +263,9 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/test_area_spawner,		/*AUTOMAPPER - SKYRAT EDIT ADDITION*/
 	/client/proc/toggle_liquid_debug,	/*SKYRAT EDIT ADDITION*/
 
-	/*FLUFFY FRONTIER ADDITION BEGIN - EVENTMAKER QOL*/
-	/datum/admins/proc/delay,
-	/datum/admins/proc/end_round,
-	/client/proc/adminchangemap,
-	/*FLUFFY FRONTIER EDIT END*/
+	/datum/admins/proc/delay,			/*FLUFFY FRONTIER ADDITION - EVENTMAKER QOL*/
+	/datum/admins/proc/end_round,		/*FLUFFY FRONTIER ADDITION - EVENTMAKER QOL*/
+	/client/proc/adminchangemap, 		/*FLUFFY FRONTIER ADDITION - EVENTMAKER QOL*/
 	)
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, GLOBAL_PROC_REF(release)))
 GLOBAL_PROTECT(admin_verbs_possess)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -135,10 +135,7 @@
 
 
 	else if(href_list["edit_shuttle_time"])
-		//FLUFFY FRONTIER CHANGE BEGIN - EVENTMAKER QOL
-		//if(!check_rights(R_SERVER)) - FLUFFY FRONTIER - ORIGINAL
-		if(!check_rights(R_ADMIN))
-		//FLUFFY FRONTIER CHANGE END
+		if(!check_rights(R_ADMIN)) //FLUFFY FRONTIER CHANGE. ORIGINAL - if(!check_rights(R_SERVER))
 			return
 
 		var/timer = input("Enter new shuttle duration (seconds):","Edit Shuttle Timeleft", SSshuttle.emergency.timeLeft() ) as num|null

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -135,7 +135,10 @@
 
 
 	else if(href_list["edit_shuttle_time"])
-		if(!check_rights(R_SERVER))
+		//FLUFFY FRONTIER CHANGE BEGIN - EVENTMAKER QOL
+		//if(!check_rights(R_SERVER)) - FLUFFY FRONTIER - ORIGINAL
+		if(!check_rights(R_ADMIN))
+		//FLUFFY FRONTIER CHANGE END
 			return
 
 		var/timer = input("Enter new shuttle duration (seconds):","Edit Shuttle Timeleft", SSshuttle.emergency.timeLeft() ) as num|null


### PR DESCRIPTION
## О Pull Request

Данный ПР сделает доступным для использования несколько кнопок для тех, у кого нет +SERVER флага. Изменённые кнопки:
- Задержка начала раунда.
- Ручной конец раунда.
- Смена карты.
- Изменение времени полёта эвакуационного шаттла.

## Как это может улучшит/повлиять на игровой процесс/ролевую игру

Ивентологам будет проще проводить некоторые вещи.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

![dreamseeker_0hMAvn1fFg](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/d87fe79d-0af2-44a2-b194-ffe9dc2ab627)

![dreamseeker_GmlggdMclF](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/bea75484-a88c-475c-a403-8533e67f0705)

</details>

## Changelog

:cl:
qol: Eventmakers now able to change map, delay round start, manualy end rounds and change shuttle arrival time!
/:cl:
