### PR TITLE
[TG Mirror] literally just maps in human spawner wands to runtimestation [MDB IGNORE]

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -80,6 +80,11 @@
 "aA" = (
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"aB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "aC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -629,22 +634,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay)
-"cH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/gun/magic/wand/resurrection/debug,
-/obj/item/gun/magic/wand/death/debug{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/medical/medbay)
 "cI" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -927,11 +916,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"dQ" = (
-/obj/structure/table,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/storage/primary)
 "dR" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -1747,6 +1731,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"hU" = (
+/turf/open/floor/circuit/green,
+/area/station/bitrunning/den)
 "ii" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1763,16 +1750,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science)
-"js" = (
-/obj/machinery/quantum_server,
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "jE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"jR" = (
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "jU" = (
 /obj/structure/table,
 /obj/item/melee/energy/axe,
@@ -1821,6 +1807,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"mi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "mE" = (
 /obj/structure/cable,
 /obj/machinery/chem_mass_spec,
@@ -1875,6 +1867,10 @@
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"qp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/bitrunning/den)
 "qx" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/unlocked,
@@ -1946,6 +1942,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"uI" = (
+/turf/closed/wall/r_wall,
+/area/station/bitrunning/den)
 "uO" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -1989,10 +1988,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"vZ" = (
-/obj/machinery/byteforge,
-/turf/open/floor/circuit/green,
-/area/station/bitrunning/den)
 "wb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -2016,10 +2011,6 @@
 "wU" = (
 /turf/closed/wall/r_wall,
 /area/station/science/explab)
-"yn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/bitrunning/den)
 "yA" = (
 /obj/docking_port/stationary/laborcamp_home{
 	dir = 8
@@ -2048,21 +2039,32 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/science)
-"Ai" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "AP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/science)
-"AR" = (
-/turf/open/floor/circuit/green,
-/area/station/bitrunning/den)
+"AS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/gun/magic/wand/resurrection/debug,
+/obj/item/gun/magic/wand/death/debug{
+	pixel_y = 10
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/debug/human_spawner{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/medical/medbay)
 "BD" = (
 /obj/structure/closet/secure_closet/chief_medical{
 	locked = 0
@@ -2079,16 +2081,14 @@
 "Ce" = (
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"Cq" = (
-/obj/machinery/door/airlock,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "Ct" = (
 /obj/structure/closet/syndicate/resources/everything,
 /turf/open/floor/iron,
 /area/station/science)
+"CD" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "CQ" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -2182,8 +2182,15 @@
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"Fk" = (
-/obj/machinery/netpod,
+"FW" = (
+/obj/machinery/byteforge,
+/turf/open/floor/circuit/green,
+/area/station/bitrunning/den)
+"Ht" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/item/storage/part_replacer/bluespace/tier4,
 /turf/open/floor/iron,
 /area/station/bitrunning/den)
 "HW" = (
@@ -2210,6 +2217,10 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"IB" = (
+/obj/machinery/quantum_server,
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "IH" = (
 /obj/structure/closet/secure_closet/engineering_welding{
 	locked = 0
@@ -2266,9 +2277,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"Ma" = (
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "Mh" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2296,27 +2304,19 @@
 /obj/machinery/chem_recipe_debug,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"Nk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "Ns" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
-"NQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/storage/part_replacer/bluespace/tier4,
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "NZ" = (
 /obj/machinery/rnd/production/protolathe/department,
 /turf/open/floor/iron,
 /area/station/science)
+"Oq" = (
+/obj/machinery/netpod,
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "Ot" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -2338,6 +2338,12 @@
 /obj/item/stock_parts/cell/bluespace,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"OA" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "OU" = (
 /obj/item/disk/tech_disk/debug,
 /turf/open/floor/iron,
@@ -2347,6 +2353,11 @@
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
+"Pw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "Px" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -2366,10 +2377,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"Qs" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "Qt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -2400,11 +2407,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"RS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "Sg" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/corner,
@@ -2420,6 +2422,11 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/medical/medbay)
+"SN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "Td" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -2480,11 +2487,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"VX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+"VV" = (
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/obj/item/debug/human_spawner,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/commons/storage/primary)
 "We" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
@@ -2527,6 +2535,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"Xo" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/computer/quantum_console,
+/turf/open/floor/iron,
+/area/station/bitrunning/den)
 "Xp" = (
 /obj/machinery/light/directional/south,
 /obj/structure/tank_dispenser{
@@ -2577,9 +2592,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
-"Yn" = (
-/turf/closed/wall/r_wall,
-/area/station/bitrunning/den)
 "Yy" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/rnd/production/circuit_imprinter/department,
@@ -2599,13 +2611,6 @@
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"Zp" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/computer/quantum_console,
-/turf/open/floor/iron,
-/area/station/bitrunning/den)
 "Zz" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/line,
@@ -3103,12 +3108,12 @@ aa
 aa
 aa
 aa
-Yn
-Yn
-Yn
-Yn
-Yn
-Yn
+uI
+uI
+uI
+uI
+uI
+uI
 aa
 aa
 aa
@@ -3195,12 +3200,12 @@ aa
 aa
 aa
 aa
-Yn
-AR
-AR
-Ma
-Fk
-Yn
+uI
+hU
+hU
+jR
+Oq
+uI
 aa
 aa
 aa
@@ -3287,12 +3292,12 @@ aa
 aa
 aa
 aa
-Yn
-AR
-vZ
-Ma
-Fk
-Yn
+uI
+hU
+FW
+jR
+Oq
+uI
 aa
 aa
 aa
@@ -3379,12 +3384,12 @@ aa
 aa
 aa
 aa
-Yn
-js
-Ma
-NQ
-Fk
-Yn
+uI
+IB
+jR
+Ht
+Oq
+uI
 aa
 aa
 aa
@@ -3471,12 +3476,12 @@ aa
 aa
 aa
 aa
-Yn
-Zp
-Qs
-RS
-Nk
-Yn
+uI
+Xo
+CD
+Pw
+SN
+uI
 aa
 aa
 aa
@@ -3563,12 +3568,12 @@ em
 em
 em
 em
-Yn
-Yn
-Yn
-Cq
-yn
-Yn
+uI
+uI
+uI
+OA
+qp
+uI
 Tj
 Tj
 Tj
@@ -3658,7 +3663,7 @@ rK
 rK
 vy
 em
-VX
+aB
 eh
 LW
 lc
@@ -3750,7 +3755,7 @@ qQ
 qQ
 ME
 em
-VX
+aB
 eh
 LW
 lc
@@ -3842,7 +3847,7 @@ qQ
 qQ
 ME
 em
-VX
+aB
 eh
 LW
 lc
@@ -3934,7 +3939,7 @@ qQ
 qQ
 CQ
 em
-Ai
+mi
 eh
 LW
 lc
@@ -4026,7 +4031,7 @@ qQ
 qQ
 ME
 em
-VX
+aB
 eh
 LW
 lc
@@ -4118,7 +4123,7 @@ qQ
 qQ
 YL
 em
-VX
+aB
 eh
 LW
 lc
@@ -4210,7 +4215,7 @@ II
 gl
 gD
 kj
-VX
+aB
 wM
 LW
 lc
@@ -7907,7 +7912,7 @@ dJ
 dJ
 dJ
 dJ
-dQ
+VV
 cS
 gz
 fO
@@ -7984,7 +7989,7 @@ Ot
 cl
 cl
 cl
-cH
+AS
 cu
 cJ
 by


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24400
Original PR: https://github.com/tgstation/tgstation/pull/79039
--------------------

## About The Pull Request

adds like two human spawner wands to runtimestation

## Why It's Good For The Game

its more convenient than spawning humans or a wand for it when you need to test with more than 3 dummies

## Changelog

runtimestation is not playerfacing
