### PR TITLE
[Skyrat Mirror] [MODULAR] Fixes a nif related runtime with update_theme

### DIFF
--- a/modular_skyrat/modules/modular_implants/code/nifsofts/soulcatcher.dm
+++ b/modular_skyrat/modules/modular_implants/code/nifsofts/soulcatcher.dm
@@ -39,6 +39,7 @@
 
 	RegisterSignal(new_soulcatcher, COMSIG_QDELETING, PROC_REF(no_soulcatcher_component))
 	linked_soulcatcher = WEAKREF(new_soulcatcher)
+	update_theme() // because we have to do this after the soulcatcher is linked
 
 /datum/nifsoft/soulcatcher/activate()
 	. = ..()
@@ -98,6 +99,9 @@
 	. = ..()
 	if(!.)
 		return FALSE // uhoh
+
+	if(isnull(linked_soulcatcher))
+		return FALSE
 
 	var/datum/component/soulcatcher/current_soulcatcher = linked_soulcatcher.resolve()
 	if(!istype(current_soulcatcher))

--- a/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
+++ b/modular_skyrat/modules/modular_implants/code/soulcatcher/soulcatcher_component.dm
@@ -454,7 +454,12 @@ GLOBAL_LIST_EMPTY(soulcatchers)
 
 /mob/dead/observer/Login()
 	. = ..()
-	var/soulcatcher_action_given = client.prefs.read_preference(/datum/preference/toggle/soulcatcher_join_action)
+	var/datum/preferences/preferences = client?.prefs
+	var/soulcatcher_action_given
+
+	if(preferences)
+		soulcatcher_action_given = preferences.read_preference(/datum/preference/toggle/soulcatcher_join_action)
+
 	if(!soulcatcher_action_given)
 		return
 


### PR DESCRIPTION
## **Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24392**
## About The Pull Request

Race condition. In the parent `/datum/nifsoft/New()` it calls `update_theme()` which expects the `linked_soulcatcher` var to be set, but it doesn't get set until the end of `/datum/nifsoft/soulcatcher/New()`. So it runtimes.

This fixes that.

Also fixes a bonus runtime:

![qALCzRpWAE](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/8ea2a8bf-bd4c-436a-8903-ff93df2b9f87)

## How This Contributes To The Skyrat Roleplay Experience

Less runtiming is good

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
  
![cgpHWBfjqy](https://github.com/Skyrat-SS13/Skyrat-tg/assets/13398309/a0522055-d031-4328-9bf4-28bb48df0943)

</details>

## Changelog

Nothing really significantly player facing I don't think?