### PR TITLE
[Skyrat Mirror] [MODULAR] Removes the 13 telecrystals contractors start with

### DIFF
--- a/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
+++ b/modular_skyrat/modules/contractor/code/datums/midround/outfit.dm
@@ -22,7 +22,7 @@
 	)
 
 	implants = list(
-		/obj/item/implant/uplink/precharged/bonus,
+		/obj/item/implant/uplink,
 	)
 
 	id_trim = /datum/id_trim/chameleon/contractor

--- a/modular_skyrat/modules/skyrat-uplinks/code/uplink_implant.dm
+++ b/modular_skyrat/modules/skyrat-uplinks/code/uplink_implant.dm
@@ -1,2 +1,0 @@
-/obj/item/implant/uplink/precharged/bonus
-	starting_tc = TELECRYSTALS_PRELOADED_IMPLANT + 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7662,7 +7662,6 @@
 #include "modular_skyrat\modules\shotgunrebalance\code\shotgun.dm"
 #include "modular_skyrat\modules\SiliconQoL\code\_onclick.dm"
 #include "modular_skyrat\modules\SiliconQoL\code\robotic_factory.dm"
-#include "modular_skyrat\modules\skyrat-uplinks\code\uplink_implant.dm"
 #include "modular_skyrat\modules\skyrat-uplinks\code\categories\bundles.dm"
 #include "modular_skyrat\modules\skyrat-uplinks\code\categories\dangerous.dm"
 #include "modular_skyrat\modules\skyrat-uplinks\code\categories\device_tools.dm"


### PR DESCRIPTION
## **Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/23582**
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR does exactly what it says on the tin. Technically, it deletes the 13tc subtype and resets contractors back to the 0tc version of the implant, but that's all backend - what **YOU**, dear reader, are reading this pr body for, is plain and clear. It does everything it says it does. One telecrystal? Nah. Three? Hell no. Twelve? Not even close. Zero! They get none. I don't know who thought giving them some was a great idea. Those angels are gone, holmes. Away. Dusted. Why?

## How This Contributes To The Skyrat Roleplay Experience

The contractor OPFOR kit and /tg/ balanced - yes, /tg/ balanced - traitor kit do not offer a 13tc discount. This is a full set of gear that would cost a traitor 20tc to get half of, and yet, you START with thirteen telecrystals. Thirteen! That's enough for a .357 magnum revolver. That's enough for sleeping carp. That's enough for enough plastic explosives to make an immovable rod look like a drunk driver.

Removing the 13tc that random-roll contractors start with evens the playing field and prevents them from getting an immensely powerful head start on their equipment with zero provided effort. Contractors have all they need at the start, from the second most powerful stun weapon in the game (abductors got that thang) to a modsuit with frankly _absurd_ protection and speed values (not counting that you start with armor plating modules!) and yet right now they have 13 extra traitor freebie points to buy even more equipment. They even start with a box of random traitor stuff already! Not included in the OPFOR/tot kits! What's not to adore already?

I'm absolutely rambling because it's 4 in the morning here, but contractors already **HAVE** some of the most powerful telecrystal gains in the game, far outpacing even lategame progtots. What might those be, you ask?

**CONTRACTS**

13tc. You want it? It's yours my friend. Just do what you clicked "yes i want to be a contractor" to do! Get those contracts! No more sleeping carp out the front gate!

## Proof of Testing

<details>

<summary>peep the folda</summary>
  
This is a really simple line change, but if a maintainer demands it or CI wrings me out like a wet towel, I'll get the testing tools on my new laptop

</details>

## Changelog

:cl: dawsonkeyes
balance: random roll contractors now start with zero telecrystals instead of thirteen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
