### PR TITLE
[TG Mirror] [NO GBP] fish analyzers can now be actually used for experiments. [MDB IGNORE]

### DIFF
--- a/code/modules/experisci/experiment/types/scanning_fish.dm
+++ b/code/modules/experisci/experiment/types/scanning_fish.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_EMPTY(scanned_fish_by_techweb)
 	name = "Fish Scanning Experiment 1"
 	description = "An experiment requiring different fish species to be scanned to unlock the 'Beach' setting for the fishing portal generator."
 	performance_hint = "Scan fish. Examine scanner to review progress. Unlock new fishing portals."
-	allowed_experimentors = list(/obj/item/experi_scanner, /obj/machinery/destructive_scanner, /obj/item/fishing_rod/tech)
+	allowed_experimentors = list(/obj/item/experi_scanner, /obj/machinery/destructive_scanner, /obj/item/fishing_rod/tech, /obj/item/fish_analyzer)
 	traits = EXPERIMENT_TRAIT_TYPECACHE
 	points_reward = list(TECHWEB_POINT_TYPE_GENERIC = 750)
 	required_atoms = list(/obj/item/fish = 4)


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24408
Original PR: https://github.com/tgstation/tgstation/pull/79030
--------------------
## About The Pull Request
I've forgot that, for some reasons, both experiments and experiment handlers have an experiment(or) whitelist var.

## Why It's Good For The Game
This will fix #78921

## Changelog

:cl: Ghommie
fix: Fish analyzers can now be actually used for experiments.
/:cl: