### PR TITLE
[TG Mirror] Announcement CSS hotfix [NO GBP] [MDB IGNORE]

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -37,7 +37,7 @@
 	else if(SSstation.announcer.event_sounds[sound])
 		sound = SSstation.announcer.event_sounds[sound]
 
-	announcement += "<br><br>"
+	announcement += "<br>"
 
 	if(type == "Priority")
 		announcement += "[span_priorityannounce("<u>Priority Announcement</u>")]"
@@ -69,7 +69,7 @@
 	else
 		announcement += "[span_priorityalert("<br>[text]<br>")]"
 
-	announcement += "<br><br>"
+	announcement += "<br>"
 
 	if(!players)
 		players = GLOB.player_list

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -370,7 +370,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	call_reason = trim(html_encode(call_reason))
 
-	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
+	var/emergency_reason = "\n\nNature of emergency:\n[call_reason]"
 
 	emergency.request(
 		signal_origin = signal_origin,

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -440,33 +440,28 @@ em {
   color: #c51e1e;
   font-weight: bold;
   font-size: 185%;
-  margin-top: 1rem;
 }
 
 .minoralert {
   color: #a4bad6;
   font-size: 125%;
-  margin-top: 1rem;
 }
 
 .priorityannounce {
   color: #a4bad6;
   font-weight: bold;
   font-size: 225%;
-  margin-top: 1rem;
 }
 
 .prioritytitle {
-  color: #9ab0ff;
+  color: #6685f5;
   font-weight: bold;
   font-size: 185%;
-  margin-top: 1rem;
 }
 
 .priorityalert {
   color: #c51e1e;
   font-size: 140%;
-  margin-top: 1rem;
 }
 
 .greenannounce {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -482,7 +482,13 @@ h2.alert {
 .priorityannounce {
   color: #000000;
   font-weight: bold;
-  font-size: 210%;
+  font-size: 225%;
+}
+
+.prioritytitle {
+  color: #0000ff;
+  font-weight: bold;
+  font-size: 185%;
 }
 
 .priorityalert {


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24413
Original PR: https://github.com/tgstation/tgstation/pull/79052
--------------------
## About The Pull Request

I forgot light mode exists half way through making PR https://github.com/tgstation/tgstation/pull/78995, apparently. Also fixes the weird spacing on shuttle evac calls and dark mode alert text, reduces the padding on either side of announcements.

![image](https://github.com/tgstation/tgstation/assets/83487515/3af555c0-24b6-425f-819a-25766e1238ba)

![image](https://github.com/tgstation/tgstation/assets/83487515/f5a1546c-567d-4d42-87af-5f5a1d8dc535)

![image](https://github.com/tgstation/tgstation/assets/83487515/05d9d5a4-7692-44ff-84c6-5abd0a1d915d)


## Changelog

:cl:  LT3
spellcheck: More announcement CSS fixes, now including light mode
/:cl: