### PR TITLE
[TG Mirror] Fixes source of tgui errors in accounts console [MDB IGNORE]

### DIFF
--- a/code/game/machinery/computer/accounting.dm
+++ b/code/game/machinery/computer/accounting.dm
@@ -21,9 +21,10 @@
 
 	for(var/current_account as anything in SSeconomy.bank_accounts_by_id)
 		var/datum/bank_account/current_bank_account = SSeconomy.bank_accounts_by_id[current_account]
+		var/job_title = current_bank_account.account_job?.title
 		player_accounts += list(list(
 			"name" = current_bank_account.account_holder,
-			"job" = current_bank_account.account_job.title,
+			"job" = job_title ? job_title : "No Job", // because this can be null
 			"balance" = round(current_bank_account.account_balance),
 			"modifier" = round((current_bank_account.payday_modifier * 0.9), 0.1),
 		))


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24412
Original PR: https://github.com/tgstation/tgstation/pull/79048
--------------------
## About The Pull Request

It's possible to have bank accounts created with `null` jobs. This results in a runtime  bluescreen that breaks the account management console for the whole round. 

<details><summary>Not ideal</summary>

![lKCRwKfZ6M](https://github.com/tgstation/tgstation/assets/13398309/e91fa68b-b1d2-437e-b77d-e7144618b2f8)

![Code_85omxswUqx](https://github.com/tgstation/tgstation/assets/13398309/c97d1ef2-4138-4cff-bdc5-0d9a1f185ba2)

</details>

The runtime comes from trying to access `title` from the null job datum in `ui_data()` which results in the ui data not being sent.

https://github.com/tgstation/tgstation/blob/c10bf15c4a9b71eec325ea2f201a68defb80943b/code/game/machinery/computer/accounting.dm#L22-L29

---

This PR just guards against that. Similar patterns can be seen everywhere else where this data is accessed.

<details><summary> For example</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/590adb03-9023-4661-93fd-ff68fb24b3f7)

![image](https://github.com/tgstation/tgstation/assets/13398309/0603a442-617f-4cb4-bc24-2561855a64d9)

</details>

## Why It's Good For The Game

More robust code, less console becoming unusable.

## Changelog

:cl: vinylspiders
fix: fixes a tgui bluescreen bug with the bank account console that can occur when there is bad bank account data
/:cl:
