### PR TITLE
[TG Mirror] Fixes a fishing balloon alert runtime [MDB IGNORE]

### DIFF
--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -245,7 +245,7 @@
 	SIGNAL_HANDLER
 	fishing_line = null
 	///The lure may be out of sight if the user has moed around a corner, so the message should be displayed over him instead.
-	user.balloon_alert(user.is_holding(used_rod) ? "line snapped" : "rod dropped")
+	user.balloon_alert(user, user.is_holding(used_rod) ? "line snapped" : "rod dropped")
 	interrupt()
 
 /datum/fishing_challenge/proc/handle_click(mob/source, atom/target, modifiers)


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24411
Original PR: https://github.com/tgstation/tgstation/pull/79050
--------------------
## About The Pull Request

![S8wPj0cMzd](https://github.com/tgstation/tgstation/assets/13398309/f06483c1-87c6-47a7-b907-043941bb2e53)

What it says on the tin. Runtime shown above, it was missing the user arg.

## Why It's Good For The Game

Bugfix

## Changelog

:cl: vinylspiders
fix: "line snapped" and "rod dropped" balloon alerts will now display when they are supposed to while fishing
/:cl:
