### PR TITLE
[TG Mirror] Updates the wizard's den [MDB IGNORE]

### DIFF
--- a/_maps/templates/lazy_templates/wizard_den.dmm
+++ b/_maps/templates/lazy_templates/wizard_den.dmm
@@ -1,505 +1,367 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/structure/curtain,
+/obj/machinery/shower/directional/north,
+/obj/item/soap/syndie,
+/turf/open/floor/noslip,
+/area/centcom/wizard_station)
 "ae" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Observation Room"
-	},
+/obj/structure/dresser,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "cm" = (
-/obj/structure/table/wood,
-/obj/item/bikehorn/golden{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/engine/cult,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron,
 /area/centcom/wizard_station)
 "cs" = (
-/turf/closed/indestructible/fakeglass{
-	color = "#008000"
+/obj/structure/railing{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "cy" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Engine Room"
-	},
-/obj/structure/barricade/wooden,
-/turf/open/floor/engine/cult,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
+"cF" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom,
+/turf/open/floor/carpet/red,
 /area/centcom/wizard_station)
 "dk" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Study"
+/obj/machinery/power/shuttle_engine/heater{
+	resistance_flags = 3
+	},
+/obj/structure/window/reinforced/spawner/directional/north{
+	resistance_flags = 3
+	},
+/turf/open/lava,
+/area/centcom/wizard_station)
+"dp" = (
+/obj/structure/showcase/machinery/rng,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"dr" = (
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_y = -9;
+	pixel_x = -5
+	},
+/obj/item/camera/spooky{
+	pixel_y = 7;
+	pixel_x = 2
 	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
-"dp" = (
-/turf/closed/indestructible/riveted/uranium,
+"dB" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"eI" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/lava,
+/area/centcom/wizard_station)
+"eW" = (
+/obj/machinery/door/airlock/wood{
+	name = "Bathroom"
+	},
+/turf/open/floor/plastic,
+/area/centcom/wizard_station)
+"fn" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
 /area/centcom/wizard_station)
 "ft" = (
-/obj/structure/destructible/cult/item_dispenser/archives/library,
-/turf/open/floor/engine/cult,
+/turf/open/floor/plastic,
 /area/centcom/wizard_station)
 "fF" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/wizard_station)
-"fX" = (
-/obj/item/cardboard_cutout,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/wizard_station)
-"gC" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/tray,
-/obj/item/food/burger/spell,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"hT" = (
+/obj/vehicle/ridden/scooter/skateboard{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
+"fX" = (
+/turf/open/lava,
+/area/centcom/wizard_station)
+"gC" = (
+/obj/structure/table,
+/obj/item/extinguisher{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/obj/item/clothing/suit/wizrobe/red{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"gX" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/plastic,
+/area/centcom/wizard_station)
+"hj" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/purple,
+/area/centcom/wizard_station)
+"hq" = (
+/obj/machinery/door/airlock/wood{
+	name = "Games Room"
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"hT" = (
+/obj/structure/flora/bush/grassy/style_random,
+/turf/open/floor/grass,
+/area/centcom/wizard_station)
 "iG" = (
-/obj/structure/bed,
-/obj/item/bedsheet/wiz,
-/turf/open/floor/carpet,
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "iQ" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/carpet,
+/obj/item/clothing/shoes/sandal/magic{
+	pixel_y = 16
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plastic,
 /area/centcom/wizard_station)
 "iW" = (
-/obj/structure/table/wood,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"jn" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/food/burger/rat{
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/item/food/bun{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"jp" = (
+/obj/machinery/door/airlock/wood{
+	name = "Ship Engine"
+	},
+/obj/structure/railing/corner/end/flip,
+/obj/structure/railing/corner/end,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"jD" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"jV" = (
+/obj/item/target,
+/obj/structure/sign/flag/nanotrasen/directional/north,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"kh" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/magic{
+	pixel_y = 36
+	},
+/turf/open/floor/plastic,
+/area/centcom/wizard_station)
+"ko" = (
+/obj/machinery/computer/shuttle,
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
+"kZ" = (
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"lL" = (
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 14;
+	pixel_x = 4
+	},
+/obj/item/toy/gun{
+	pixel_y = 2;
+	pixel_x = -3
+	},
+/obj/item/clothing/head/wizard/red{
+	pixel_x = 6;
+	pixel_y = -10
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"mc" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/suit/wizrobe/tape,
 /obj/item/gun/magic/wand{
 	desc = "Used in emergencies to reignite magma engines.";
 	max_charges = 0;
 	name = "wand of emergency engine ignition"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
-"jn" = (
-/obj/item/food/meat/slab/corgi,
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"jp" = (
+"nc" = (
 /obj/structure/table/wood,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
-"jD" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"jV" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"kh" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"ko" = (
-/obj/structure/showcase/machinery/rng,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"kZ" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"lL" = (
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"mc" = (
-/obj/structure/closet/crate/preopen,
-/obj/item/clothing/suit/wizrobe/red,
-/obj/item/clothing/head/wizard/red,
-/obj/item/staff,
-/obj/item/clothing/shoes/sandal/magic,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
 "nN" = (
-/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/door/airlock/wood{
+	name = "Kitchen"
+	},
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"nV" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/mob/living/simple_animal/hostile/ooze/gelatinous{
+	name = "Jimmy"
+	},
 /turf/open/floor/grass,
 /area/centcom/wizard_station)
 "oh" = (
-/obj/item/food/meat/slab/human/mutant/slime,
-/turf/open/floor/grass,
+/obj/item/cardboard_cutout/adaptive{
+	pixel_y = 14;
+	pixel_x = 8
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "om" = (
-/obj/structure/showcase/wizard,
+/obj/structure/table/wood,
+/obj/item/storage/dice{
+	icon_state = "magicdicebag";
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/obj/item/dice/d20{
+	pixel_y = 4;
+	pixel_x = 2
+	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "op" = (
 /turf/open/space/transit,
 /area/space)
 "ov" = (
-/obj/effect/landmark/start/wizard,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "ow" = (
-/turf/open/floor/iron/white,
+/obj/structure/table,
+/obj/item/bikehorn/rubberducky{
+	pixel_y = 5;
+	pixel_x = -11
+	},
+/obj/item/clothing/head/wizard{
+	pixel_y = 14;
+	pixel_x = 4
+	},
+/turf/open/floor/plastic,
 /area/centcom/wizard_station)
 "oE" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Bathroom"
+/obj/item/flashlight/flare{
+	pixel_x = -5;
+	pixel_y = -12
 	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "pa" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/wizard/tape,
-/obj/item/clothing/suit/wizrobe/tape,
-/obj/item/staff/tape,
-/obj/item/stack/sticky_tape/super,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "pq" = (
-/obj/item/soap/homemade,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/bookcase/random/reference/wizard,
+/turf/open/floor/iron,
 /area/centcom/wizard_station)
 "pt" = (
-/obj/machinery/vending/magivend,
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 21;
+	pixel_x = 6
+	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "pw" = (
-/obj/machinery/computer/camera_advanced{
-	dir = 4
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 1;
+	pixel_x = -6
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/centcom/wizard_station)
 "pA" = (
-/obj/machinery/power/shuttle_engine/propulsion,
-/turf/open/floor/plating/airless,
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 21;
+	pixel_x = 6
+	},
+/turf/open/floor/carpet/red,
 /area/centcom/wizard_station)
 "pI" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/photo_album,
-/turf/open/floor/carpet,
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "qe" = (
-/turf/open/floor/grass,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/griddle,
+/turf/open/floor/iron,
 /area/centcom/wizard_station)
 "qg" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Storage"
+/obj/structure/railing{
+	layer = 3.1
+	},
+/obj/structure/railing{
+	layer = 3.1;
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"ql" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 6;
+	pixel_y = 14
+	},
+/obj/item/book/manual/wiki/ordnance{
+	pixel_y = 4;
+	pixel_x = 3;
+	page_link = "Wizard";
+	name = "Wizarding Tome - How to Wizard";
+	desc = "Everything you need to know to be a wizard."
+	},
+/obj/item/stack/medical/bruise_pack{
+	pixel_x = -12
+	},
+/obj/item/reagent_containers/cup/glass/mug/coco{
+	pixel_x = -11;
+	pixel_y = 1
 	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "qo" = (
-/obj/structure/punching_bag,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"qM" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/centcom/wizard_station)
-"sx" = (
-/obj/structure/table/wood,
-/obj/item/retractor,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"tv" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/mob/living/basic/creature{
-	name = "Experiment 35b"
-	},
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"tz" = (
-/obj/structure/table/wood/fancy,
-/obj/item/camera/spooky,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"ut" = (
-/obj/structure/bookcase/random/adult,
-/turf/open/floor/iron/white,
-/area/centcom/wizard_station)
-"uy" = (
-/obj/structure/chair/wood/wings{
+/obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/centcom/wizard_station)
-"wk" = (
-/obj/structure/table/wood/fancy,
-/obj/item/skub{
-	pixel_y = 16
-	},
-/turf/open/floor/iron/white,
-/area/centcom/wizard_station)
-"wY" = (
-/obj/item/food/meat/slab/xeno,
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"xc" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/figure/wizard,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"xd" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"xn" = (
-/obj/item/clothing/suit/wizrobe/black,
-/obj/item/clothing/head/wizard/black,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/wizard_station)
-"zB" = (
-/obj/machinery/computer/camera_advanced,
-/turf/open/floor/wood,
-/area/centcom/wizard_station)
-"Ad" = (
-/obj/structure/table/wood,
-/obj/item/dice/d20,
-/obj/item/dice,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"Ar" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"AW" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"Cm" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"Do" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/white,
-/area/centcom/wizard_station)
-"Dq" = (
-/obj/effect/decal/remains/xeno/larva,
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"DX" = (
-/obj/item/clothing/shoes/sneakers/marisa,
-/obj/item/clothing/suit/wizrobe/marisa,
-/obj/item/clothing/head/wizard/marisa,
-/obj/item/staff/broom,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"Ej" = (
-/obj/item/coin/antagtoken,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/wizard_station)
-"GE" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/centcom/wizard_station)
-"GV" = (
-/obj/item/cautery/alien,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/centcom/wizard_station)
-"Hk" = (
-/obj/structure/dresser,
-/obj/item/storage/backpack/satchel,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"HD" = (
-/obj/vehicle/ridden/scooter/skateboard{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/centcom/wizard_station)
-"HX" = (
-/obj/structure/chair/wood/wings,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"IZ" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"JN" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"JQ" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"JW" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Personal Quarters"
-	},
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"Lt" = (
-/turf/open/floor/wood,
-/area/centcom/wizard_station)
-"LU" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Observation Deck"
-	},
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"MW" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/dice{
-	icon_state = "magicdicebag"
-	},
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"Ol" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Cockpit"
-	},
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"OV" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	color = "#008000";
-	resistance_flags = 3
-	},
-/turf/open/lava,
-/area/centcom/wizard_station)
-"Pz" = (
-/obj/structure/destructible/cult/item_dispenser/altar{
-	desc = "An altar dedicated to the Wizard Federation."
-	},
-/obj/item/knife/ritual,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"PF" = (
-/obj/structure/table/wood,
-/obj/item/clothing/suit/wizrobe/magusred,
-/obj/item/clothing/head/wizard/magus,
-/obj/item/staff,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"PK" = (
-/obj/structure/chair/wood/wings,
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"RT" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck/wizoff{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/toy/cards/deck/tarot{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"RY" = (
-/obj/machinery/power/shuttle_engine/heater{
-	resistance_flags = 3
-	},
-/obj/structure/window/reinforced/spawner/directional/north{
-	color = "#008000";
-	resistance_flags = 3
-	},
-/turf/open/lava/airless,
-/area/centcom/wizard_station)
-"Sg" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"Si" = (
-/obj/structure/table/wood/fancy,
-/obj/item/radio/headset,
-/turf/open/floor/wood,
-/area/centcom/wizard_station)
-"SD" = (
-/obj/structure/bookcase/random/reference/wizard,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"Tl" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"TG" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Break Room"
-	},
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"TX" = (
-/obj/structure/urinal/directional/north,
-/turf/open/floor/iron/white,
-/area/centcom/wizard_station)
-"Ug" = (
-/obj/structure/mirror/magic{
-	pixel_y = 28
-	},
-/obj/structure/sink/directional/south,
-/turf/open/floor/iron/white,
-/area/centcom/wizard_station)
-"UC" = (
-/obj/machinery/computer/shuttle,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"UG" = (
-/obj/item/statuebust{
-	pixel_y = 12
-	},
-/obj/structure/table/wood/fancy,
-/turf/open/floor/wood,
-/area/centcom/wizard_station)
-"VB" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/centcom/wizard_station)
-"VO" = (
-/obj/structure/destructible/cult/item_dispenser/forge/engine,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"WQ" = (
-/obj/machinery/door/airlock{
-	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
-	name = "Game Room"
-	},
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"WY" = (
-/obj/effect/decal/remains/xeno,
-/turf/open/floor/grass,
-/area/centcom/wizard_station)
-"Xt" = (
-/obj/structure/table/wood,
-/obj/item/clothing/suit/wizrobe/magusblue,
-/obj/item/clothing/head/wizard/magus,
-/obj/item/staff,
-/obj/structure/mirror/magic{
-	pixel_y = 28
-	},
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"XJ" = (
 /mob/living/simple_animal/bot/medbot/mysterious{
 	desc = "If you don't accidentally blow yourself up from time to time you're not really a wizard anyway.";
 	faction = list("neutral","silicon","creature");
@@ -507,34 +369,605 @@
 	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
-"XV" = (
-/obj/structure/chair/wood/wings,
+"qM" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/wizrobe/black{
+	pixel_y = 3;
+	pixel_x = -1
+	},
+/obj/item/clothing/head/wizard/black{
+	pixel_y = 13;
+	pixel_x = 6
+	},
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
-"Yp" = (
+"sx" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/centcom/wizard_station)
+"tv" = (
+/obj/structure/destructible/cult/item_dispenser/archives/library,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"tz" = (
+/turf/open/floor/carpet/purple,
+/area/centcom/wizard_station)
+"tQ" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"ua" = (
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Firing Range"
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"ut" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/purple,
+/area/centcom/wizard_station)
+"uy" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"uT" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/south,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"vG" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/bureaucracy/paper{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/obj/item/pen{
+	pixel_x = -5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/coin/antagtoken{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"wk" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/centcom/wizard_station)
+"wQ" = (
+/obj/structure/mirror/magic{
+	pixel_x = 32
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"wY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"xc" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"xd" = (
+/obj/structure/table/wood,
+/obj/item/radio/headset{
+	pixel_y = 6;
+	pixel_x = 5
+	},
+/obj/item/radio/headset{
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
+"xf" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/wizard{
+	pixel_y = 16;
+	pixel_x = 4
+	},
+/obj/item/toy/cards/deck/tarot{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/toy/cards/deck/wizoff{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"xn" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"xF" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"ya" = (
+/obj/structure/table/wood/fancy,
+/obj/item/skub{
+	pixel_y = 16
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plastic,
+/area/centcom/wizard_station)
+"yO" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plastic,
+/area/centcom/wizard_station)
+"yX" = (
+/obj/structure/railing{
+	layer = 3.1
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"zB" = (
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"Ad" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Ar" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"AW" = (
+/mob/living/simple_animal/pet/gondola{
+	name = "Jommy"
+	},
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/centcom/wizard_station)
+"Cm" = (
+/turf/open/floor/grass,
+/area/centcom/wizard_station)
+"Df" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/chair/wood,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"Do" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Storage"
+	},
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Dq" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = -8;
+	pixel_y = 17
+	},
+/obj/item/pai_card{
+	pixel_y = 8;
+	pixel_x = 4
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Dy" = (
+/obj/machinery/door/window/right/directional/east,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"DX" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Ej" = (
+/obj/structure/sign/departments/restroom/directional/west,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"GE" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/centcom/wizard_station)
+"Hk" = (
+/obj/machinery/power/shuttle_engine/heater{
+	resistance_flags = 3
+	},
+/obj/structure/window/reinforced/spawner/directional/north{
+	resistance_flags = 3
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"HD" = (
+/obj/structure/table/wood,
+/obj/item/storage/photo_album,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"HX" = (
+/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"II" = (
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"IZ" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Jn" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/boritos/purple,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"JN" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/item/food/burger/yellow{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/obj/item/food/burger/red{
+	pixel_y = 13;
+	pixel_x = 6
+	},
+/obj/item/food/burger/purple{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"JQ" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/table/reinforced,
+/obj/item/food/burger/spell{
+	pixel_y = 11;
+	pixel_x = -3
+	},
+/obj/item/stack/medical/ointment{
+	pixel_y = -2;
+	pixel_x = 9
+	},
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"JW" = (
+/obj/machinery/door/window/left/directional/east,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"KL" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Lt" = (
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 1;
+	pixel_x = -6
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"LU" = (
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
+"MT" = (
+/obj/effect/turf_decal/stripes,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"MW" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/plastic,
+/area/centcom/wizard_station)
+"Ol" = (
+/obj/machinery/computer/camera_advanced,
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"OV" = (
+/obj/machinery/door/airlock/wood{
+	name = "Master Bedroom"
+	},
+/obj/effect/mapping_helpers/airlock_note_placer{
+	note_info = "Don't forget the book above your desk. Also, your other clothes are in your dresser. -Mom"
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Pb" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
+"Pz" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/centcom/wizard_station)
+"PF" = (
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = 11;
+	pixel_y = 17
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"PK" = (
+/obj/item/clothing/suit/wizrobe/magusblue,
+/obj/item/clothing/suit/wizrobe/magusred,
+/obj/item/clothing/head/wizard/magus,
+/obj/structure/closet,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Qm" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"RR" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/wizard{
+	pixel_y = 2;
+	pixel_x = -5
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"RT" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"RY" = (
+/obj/item/cautery/alien,
+/obj/structure/closet/crate,
+/obj/item/stack/sticky_tape/super,
+/obj/item/clothing/head/wizard/tape,
+/obj/item/bikehorn/golden{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Sg" = (
+/obj/machinery/computer/camera_advanced,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Si" = (
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 21;
+	pixel_x = -7
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"St" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/wiz{
+	dir = 1
+	},
+/obj/effect/landmark/start/wizard,
+/obj/machinery/light/directional/west,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"SD" = (
+/obj/structure/destructible/cult/item_dispenser/altar{
+	desc = "An altar dedicated to the Wizard Federation."
+	},
+/obj/structure/sign/poster/contraband/the_big_gas_giant_truth/directional/north,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Tl" = (
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/open/floor/carpet/purple,
+/area/centcom/wizard_station)
+"TG" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/wizard_station)
+"TM" = (
+/obj/structure/rack,
+/obj/item/knife/ritual{
+	pixel_y = 5
+	},
+/obj/item/staff{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/staff/broom,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"TX" = (
+/obj/structure/destructible/cult/item_dispenser/forge/engine,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Ug" = (
+/obj/structure/closet/crate,
+/obj/item/staff/tape,
+/obj/effect/spawner/random/exotic/languagebook,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/storage/crayons,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"UC" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/carbon{
+	pixel_y = 12;
+	pixel_x = 7
+	},
+/obj/item/stamp/granted{
+	pixel_y = 2;
+	pixel_x = 8
+	},
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"UG" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"UX" = (
+/obj/machinery/vending/magivend,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"VB" = (
+/turf/closed/indestructible/wood,
+/area/centcom/wizard_station)
+"VO" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/sink/directional/west,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"VV" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
+/area/centcom/wizard_station)
+"Wh" = (
+/obj/item/target{
+	pixel_y = 11
+	},
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"WQ" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"WY" = (
+/obj/structure/closet/crate/coffin,
+/obj/item/clothing/under/rank/civilian/curator,
+/obj/item/food/meat/slab/human/mutant/skeleton,
+/obj/item/bodypart/arm/left/skeleton,
+/obj/item/bodypart/chest/skeleton,
+/obj/item/bodypart/head/skeleton,
+/obj/item/food/meat/slab/human/mutant/skeleton,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Xt" = (
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 21;
+	pixel_x = -7
+	},
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
+"XJ" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
+"XV" = (
+/obj/machinery/door/airlock/wood{
+	name = "Library"
+	},
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Ya" = (
+/obj/structure/filingcabinet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"Yp" = (
+/obj/structure/railing/corner/end/flip,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"Yq" = (
+/obj/structure/chair/wood/wings,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "Yv" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table/wood,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment,
-/turf/open/floor/engine/cult,
-/area/centcom/wizard_station)
-"YT" = (
-/obj/structure/closet/cardboard,
-/obj/item/banhammer,
-/obj/effect/turf_decal/stripes/line,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 12;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/trash/candle{
+	pixel_x = 7;
+	pixel_y = 1
+	},
 /turf/open/floor/iron,
 /area/centcom/wizard_station)
+"YT" = (
+/obj/structure/showcase/wizard,
+/turf/open/floor/carpet/red,
+/area/centcom/wizard_station)
 "ZA" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/structure/closet/crate,
+/obj/item/banhammer,
+/obj/item/toy/eldritch_book,
+/turf/open/floor/engine/cult,
+/area/centcom/wizard_station)
+"ZI" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/closet/crate/bin,
+/obj/item/trash/shok_roks/berry,
+/turf/open/floor/iron,
+/area/centcom/wizard_station)
+"ZR" = (
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 1;
+	pixel_x = -6
 	},
-/turf/open/floor/iron/white,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 
 (1,1,1) = {"
@@ -736,11 +1169,11 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
+VB
+VB
+VB
+VB
+VB
 op
 op
 op
@@ -781,27 +1214,27 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
+VB
+VB
+uy
+St
+ae
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
 op
 op
 op
@@ -826,29 +1259,29 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-op
+VB
+VB
+uy
+kZ
+kZ
+kZ
+VB
+MW
+yO
+ya
+gX
+ac
+VB
+jV
+Qm
+cm
+iW
+kZ
+kZ
+DX
+kZ
+dk
+GE
 op
 op
 op
@@ -872,29 +1305,29 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-op
-op
-op
-dp
-dp
-cs
-cs
-cs
-dp
-dp
-op
-op
-op
-op
-op
-op
-op
+TG
+II
+RT
+kZ
+kZ
+pI
+VB
+MW
+ft
+ft
+ow
+iQ
+VB
+jV
+zB
+Wh
+iW
+kZ
+kZ
+kZ
+kZ
+dk
+GE
 op
 op
 op
@@ -918,29 +1351,29 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-dp
-dp
-dp
-dp
-HX
+TG
+ql
+kZ
+kZ
+Jn
+VB
+VB
+VB
+VB
+kh
 ft
-SD
 ft
+VB
+jV
 Yp
-dp
+MT
 cs
-cs
-dp
-op
-op
-op
-op
+ov
+ov
+JW
+Dy
+dk
+GE
 op
 op
 op
@@ -964,28 +1397,28 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-dp
-dp
+VB
+TM
+kZ
+kZ
+VB
+VB
+hj
 pw
-Lt
-dk
-hT
-hT
-hT
-hT
-hT
-LU
-hT
-hT
-dp
-dp
-op
-op
+VB
+VB
+eW
+VB
+VB
+VB
+VB
+VB
+qo
+kZ
+kZ
+kZ
+pI
+VB
 op
 op
 op
@@ -1007,33 +1440,33 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-op
-dp
-dp
-Si
-qM
+TG
+TG
+TG
+VB
+SD
+kZ
+UG
+VB
+UX
+tz
+tz
 Lt
-dp
-hT
-hT
-hT
-hT
-hT
-dp
-hT
+VB
+kZ
+Ej
+kZ
+Lt
+uy
+VB
+VB
 lL
-hT
-dp
-dp
-dp
-dp
-dp
+gC
+kZ
+VB
+VB
+op
+op
 op
 op
 op
@@ -1052,37 +1485,37 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-op
-dp
-dp
-Lt
-Lt
-Lt
-Lt
-dp
+TG
+TG
+qM
+RR
+VB
+tv
+kZ
+kZ
+OV
+kZ
+tz
+tz
+kZ
 XV
-ft
-hT
-ft
-IZ
-dp
-hT
-hT
-Cm
-dp
-xn
-GV
-YT
-dp
-dp
-cs
-dp
+kZ
+kZ
+dB
+kZ
+kZ
+uy
+VB
+VB
+VB
+ua
+VB
+op
+op
+op
+op
+op
+op
 op
 op
 op
@@ -1098,37 +1531,37 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-op
-dp
-zB
+TG
+Sg
+jD
+ZR
+VB
+VB
+wQ
+pI
+VB
 uy
-Lt
-Lt
-Lt
-dp
-dp
-cs
-cs
-cs
-dp
-dp
-hT
-lL
-hT
-qg
-fF
-fF
-GE
-cy
-hT
-hT
-dp
+tz
+tz
+kZ
+VB
+VB
+VB
+VB
+pt
+kZ
+kZ
+uy
+VB
+TX
+yX
+VB
+VB
+op
+op
+op
+op
+op
 op
 op
 op
@@ -1144,39 +1577,39 @@ op
 op
 op
 op
-op
-op
-op
-op
+TG
+Ol
+kZ
+kZ
 dp
-dp
-dp
-dp
-Si
-Lt
-Lt
-Lt
-UG
-dp
-Yv
+VB
+VB
+VB
+VB
+uy
+tz
+tz
+kZ
+VB
 hT
-hT
-hT
-XJ
-dp
-hT
-hT
-hT
-dp
+nV
+VB
+VB
+kZ
+kZ
+uy
+VB
 fX
-Ej
-HD
-dp
-dp
-cy
-dp
-dp
-dp
+qg
+fX
+VB
+VB
+op
+op
+op
+op
+op
+op
 op
 op
 op
@@ -1190,39 +1623,39 @@ op
 op
 op
 op
-op
-op
-op
-dp
-dp
-Sg
-ko
-dp
-dp
-dp
-ae
-dp
-dp
-dp
+TG
+cF
+LU
+LU
+LU
+LU
+LU
+LU
+Pb
+LU
+tz
+tz
+LU
+TG
 sx
+Cm
 hT
-hT
-hT
-hT
-dp
-hT
-lL
-hT
-dp
-dp
-dp
-dp
-dp
-Sg
-hT
-VO
-OV
-dp
+VB
+pA
+LU
+cy
+VB
+eI
+qg
+fX
+fX
+dk
+GE
+op
+op
+op
+op
+op
 op
 op
 op
@@ -1236,40 +1669,40 @@ op
 op
 op
 op
-op
-op
-op
-cs
-hT
-hT
-hT
-cs
-hT
-Sg
-hT
-hT
-pt
-dp
-AW
-hT
-hT
-hT
-hT
-cs
-hT
-hT
-hT
-dp
-Ad
-xd
-Hk
-dp
+TG
+ko
+fn
+LU
+LU
+LU
+LU
+LU
+LU
+LU
+tz
+tz
+LU
+TG
+Cm
+VV
+Cm
+VB
+YT
+LU
+LU
 jp
-hT
-hT
-OV
-RY
-pA
+KL
+HX
+Ad
+Ad
+Hk
+GE
+op
+op
+op
+op
+op
+op
 op
 op
 "}
@@ -1282,40 +1715,40 @@ op
 op
 op
 op
-op
-op
-op
-cs
-UC
-hT
-hT
-Ol
-hT
-hT
-hT
-hT
-hT
 TG
-hT
-hT
-Pz
-ov
-hT
+xd
 LU
-hT
-lL
-hT
-JW
-lL
-iG
-lL
-cs
-iW
-hT
-hT
-OV
-RY
-pA
+LU
+LU
+LU
+LU
+LU
+XJ
+LU
+tz
+tz
+LU
+TG
+Cm
+wk
+Pz
+VB
+Xt
+LU
+cy
+VB
+fX
+qg
+fX
+fX
+dk
+GE
+op
+op
+op
+op
+op
+op
 op
 op
 "}
@@ -1328,40 +1761,40 @@ op
 op
 op
 op
-op
-op
-op
-cs
-hT
-hT
-hT
-cs
-hT
-jV
-hT
-hT
-jD
-dp
+TG
+Ol
+kZ
+kZ
+xn
+VB
+VB
+VB
+VB
+uy
+tz
+tz
+kZ
+VB
 AW
 hT
-hT
-hT
-hT
-cs
-hT
-hT
-hT
-dp
-qo
-iQ
-gC
-dp
-pa
-hT
-hT
-OV
-RY
-pA
+VB
+VB
+kZ
+kZ
+uy
+VB
+fX
+qg
+fX
+VB
+VB
+op
+op
+op
+op
+op
+op
+op
 op
 op
 "}
@@ -1374,39 +1807,39 @@ op
 op
 op
 op
-op
-op
-op
-dp
-dp
-jV
+TG
+Sg
+jD
+pI
+VB
+VB
 om
 dp
-dp
-dp
-WQ
-dp
-dp
-dp
-Xt
-hT
-hT
-hT
-hT
-dp
-hT
-lL
-hT
-dp
-dp
-dp
-dp
-dp
-cm
-hT
-VO
-OV
-dp
+VB
+uy
+tz
+tz
+kZ
+VB
+VB
+VB
+VB
+Si
+kZ
+kZ
+uy
+VB
+fX
+qg
+VB
+VB
+op
+op
+op
+op
+op
+op
+op
 op
 op
 op
@@ -1420,39 +1853,39 @@ op
 op
 op
 op
-op
-op
-op
-op
-dp
-dp
-dp
-dp
-lL
-Tl
-lL
+TG
+TG
+dr
+HD
+VB
+Dq
+kZ
+kZ
+hq
+kZ
 tz
-MW
-dp
-PF
-mc
+tz
+kZ
+XV
+kZ
+kZ
 DX
-hT
-hT
-dp
-hT
-hT
-hT
-dp
-TX
-pq
-ut
-dp
-dp
-cs
-dp
-dp
-dp
+kZ
+kZ
+uy
+VB
+VB
+VB
+Do
+VB
+op
+op
+op
+op
+op
+op
+op
+op
 op
 op
 op
@@ -1467,33 +1900,33 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-dp
-PK
-xc
+TG
+TG
+TG
 VB
-lL
+nc
+kZ
+kZ
+VB
+xc
+tz
+tz
 pI
-dp
-dp
-cs
-cs
-cs
-dp
-dp
-hT
-lL
-hT
+VB
+kZ
+kZ
+kZ
+pI
+uy
+VB
+VB
+pa
+wY
 oE
-ow
-ow
-ZA
-dp
+VB
+VB
+op
+op
 op
 op
 op
@@ -1516,30 +1949,30 @@ op
 op
 op
 op
-op
-op
-op
-dp
-dp
-kh
-lL
+VB
+xf
+kZ
+UG
+VB
+VB
+ut
 Tl
-lL
-cs
+VB
+VB
 nN
+VB
+VB
+VB
+VB
+VB
+RY
 kZ
-tv
-JN
+uy
 kZ
-cs
-hT
-hT
-Cm
-dp
 Ug
-Do
-wk
-dp
+VB
+op
+op
 op
 op
 op
@@ -1562,30 +1995,30 @@ op
 op
 op
 op
-op
-op
-op
-op
-dp
-dp
+TG
 PK
-RT
+kZ
+kZ
+kZ
 VB
-cs
+VB
+VB
+VB
+ZI
 Ar
 qe
-Ar
+VB
 oh
-Ar
-cs
-hT
-lL
-hT
-dp
-dp
-dp
-dp
-dp
+kZ
+wY
+kZ
+wY
+uy
+wY
+ZA
+dk
+GE
+op
 op
 op
 op
@@ -1608,29 +2041,29 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-dp
-dp
+TG
+iG
+kZ
+kZ
+WQ
+Lt
+VB
 JQ
-lL
-cs
-Dq
+Ar
+Ar
+Ar
 jn
+VB
+mc
 kZ
-qe
+uy
+wY
 kZ
-cs
-hT
-hT
-dp
-dp
-op
-op
-op
+wY
+kZ
+fF
+dk
+GE
 op
 op
 op
@@ -1654,29 +2087,29 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-dp
-dp
-dp
-dp
-kZ
-qe
-Ar
+VB
+VB
+PF
+Yq
+tQ
+uT
+VB
+pq
+Df
+Yv
+VO
+JN
+VB
 WY
 wY
-dp
-cs
-cs
-dp
-op
-op
-op
-op
+wY
+kZ
+Ya
+IZ
+UC
+vG
+dk
+GE
 op
 op
 op
@@ -1701,27 +2134,27 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
-op
-op
-op
-dp
-dp
-dp
-dp
-dp
-dp
-dp
-op
-op
-op
-op
-op
-op
+VB
+VB
+kZ
+xF
+pI
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
+VB
 op
 op
 op
@@ -1748,11 +2181,11 @@ op
 op
 op
 op
-op
-op
-op
-op
-op
+VB
+VB
+VB
+VB
+VB
 op
 op
 op


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24373
Original PR: https://github.com/tgstation/tgstation/pull/78723
--------------------
## About The Pull Request

I am the mapping demon, the mapping vampire, the mapping LICH. I am going to suck the soul out of every single map in the game. I've sucked the beach away mission's soul now I'm going for the wizard's den.

## Why It's Good For The Game

The wizard's den no longer looks like a giant flying cucumber, also it looks a lot better and has a lot better themeing. The wizard also has a book directing them to their wiki page to help them.

![image](https://github.com/tgstation/tgstation/assets/84548101/66f8a003-30be-447f-8c99-fc61fd6c6828)
![image](https://github.com/tgstation/tgstation/assets/84548101/c9ab3ab8-ad0e-4788-8f03-044a475849ee)
![image](https://github.com/tgstation/tgstation/assets/84548101/0073c19c-22dd-4b33-b3a9-948c5c62f3a9)
![image](https://github.com/tgstation/tgstation/assets/84548101/8e347368-5ced-4e7c-b03e-7df4fc5da8fa)
![image](https://github.com/tgstation/tgstation/assets/84548101/5dbb989c-cfc2-43a9-b8c5-8ab33cdc76eb)
![image](https://github.com/tgstation/tgstation/assets/84548101/81ee2615-0866-4368-baf3-943e62894321)


## Changelog
:cl:  Fazzie
add: The wizard's den now has a book with the guide to wizard. Hope that helps their winrate!
qol: The wizard's den no longer looks like a flying cucumber and has received a major overhaul. Hooray!
/:cl:
