### PR TITLE
[Skyrat Mirror] interdyne - gives miners point cards, places sansufentanyl in the medical area

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -1825,6 +1825,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/closet/crate/freezer/sansufentanyl,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "oZ" = (

--- a/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/LavaRuins/skyrat/lavaland_surface_syndicate_base1_skyrat.dmm
@@ -1177,6 +1177,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/closet/crate/freezer/sansufentanyl,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/medbay)
 "mk" = (

--- a/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
+++ b/modular_skyrat/modules/mapping/code/lavaland_ruin_code.dm
@@ -62,7 +62,8 @@
 		/obj/item/mining_voucher=1,
 		/obj/item/t_scanner/adv_mining_scanner/lesser=1,
 		/obj/item/gun/energy/recharge/kinetic_accelerator=1,\
-		/obj/item/stack/marker_beacon/ten=1)
+		/obj/item/stack/marker_beacon/ten=1,\
+		/obj/item/card/mining_point_card=1)
 
 /datum/outfit/lavaland_syndicate/shaftminer/deckofficer
 	name = "Interdyne Deck Officer"
@@ -94,7 +95,7 @@
 	icon_state = "syndie_headset"
 	inhand_icon_state = null
 	radiosound = 'modular_skyrat/modules/radiosound/sound/radio/syndie.ogg'
-	keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne
+	keyslot = /obj/item/encryptionkey/headset_syndicate/interdyne
 
 /obj/item/radio/headset/interdyne/Initialize(mapload)
 	. = ..()
@@ -106,9 +107,18 @@
 	command = TRUE
 
 /obj/item/radio/headset/interdyne/comms
-	keyslot = new /obj/item/encryptionkey/headset_syndicate/interdyne
-	keyslot2 = new /obj/item/encryptionkey/syndicate
-	
+	keyslot = /obj/item/encryptionkey/headset_syndicate/interdyne
+	keyslot2 = /obj/item/encryptionkey/syndicate
+
+/obj/structure/closet/crate/freezer/sansufentanyl
+	name = "sansufentanyl crate"
+	desc = "A freezer. Contains refrigerated Sansufentanyl, for managing Hereditary Manifold Sickness. A product of Interdyne Pharmaceuticals."
+
+/obj/structure/closet/crate/freezer/sansufentanyl/PopulateContents()
+	. = ..()
+	for(var/grabbin_pills in 1 to 10)
+		new /obj/item/storage/pill_bottle/sansufentanyl(src)
+
 //MOBS
 
 // hivelords that stand guard where they spawn


### PR DESCRIPTION
## **Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24375**
## About The Pull Request
miners now spawn with a point card in their otherwise underfilled backpack
medical areas now have a sansufentanyl crate next to the blood freezer

## How This Contributes To The Skyrat Roleplay Experience
mining cards: point transfer good
medical sansufentanyl: trade goods for potential HMS sufferers
## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/9ac83d27-46a3-49bd-80ef-0d27fdff81d1)
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/31829017/605d7433-741d-4de7-aedc-17dd26fe2254)
</details>

## Changelog
:cl: Hatterhat
qol: Interdyne miners now spawn with a point transfer card in their backpacks.
qol: Sansufentanyl now spawns in the Interdyne base, since it's something they make in-lore. It can be found in a freezer crate next to their blood freezer.
/:cl:
