### PR TITLE
[TG Mirror] Birdshot ordnance QoL 

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -85,6 +85,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
+"acO" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "acS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -897,13 +905,6 @@
 	},
 /turf/open/floor/iron/kitchen/small,
 /area/station/maintenance/aft)
-"ase" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "asf" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -1195,10 +1196,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ays" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/frame/machine,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "ayu" = (
@@ -2404,13 +2403,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
-"aWy" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/item/stack/sheet/mineral/titanium,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "aWC" = (
 /obj/machinery/computer/department_orders/engineering{
 	dir = 8
@@ -2470,6 +2462,12 @@
 	dir = 8
 	},
 /area/station/command/corporate_showroom)
+"aYO" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/tram,
+/area/station/security/tram)
 "aYR" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4221,10 +4219,9 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "bFG" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/structure/frame/machine,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/item/stack/sheet/mineral/titanium,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "bFM" = (
@@ -4274,12 +4271,6 @@
 /obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/small,
 /area/station/medical/morgue)
-"bGm" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "bGn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -4660,14 +4651,6 @@
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"bOQ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "bOR" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/flora/bush/flowers_yw,
@@ -4716,6 +4699,13 @@
 /obj/machinery/computer/records/security,
 /turf/open/floor/wood/tile,
 /area/station/command/bridge)
+"bQz" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "bQU" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -4978,11 +4968,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/tram)
-"bVC" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "bVD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6042,6 +6027,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"crr" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "crE" = (
 /obj/structure/window/spawner/directional/north,
 /turf/open/space/basic,
@@ -6052,15 +6044,6 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/security/brig)
-"crV" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/fluff/tram_rail/floor{
-	dir = 1
-	},
-/obj/structure/thermoplastic,
-/obj/structure/rack,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "csl" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -6161,14 +6144,13 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
-"cum" = (
+"cuG" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+	dir = 8
 	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
-/area/station/security/tram)
+/area/station/maintenance/department/medical/central)
 "cuS" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -6231,6 +6213,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"cwd" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/obj/machinery/computer/tram_controls{
+	specific_transport_id = "bird_2"
+	},
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "cwf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6634,6 +6627,18 @@
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
+"cDg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "rdordnance";
+	name = "Ordnance Lab Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/science/ordnance)
 "cDh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6906,17 +6911,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
-"cHt" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/fluff/tram_rail/floor{
-	dir = 1
-	},
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left{
-	dir = 1
-	},
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "cHC" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -6998,7 +6992,10 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/engine)
 "cJu" = (
-/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "cJz" = (
@@ -7650,17 +7647,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"cWb" = (
-/obj/structure/transport/linear/tram,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/structure/fluff/tram_rail/floor{
-	dir = 1
-	},
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "cWh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7913,12 +7899,9 @@
 /turf/open/floor/plating/rust,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "dbO" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/structure/frame/computer{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "dbR" = (
@@ -8154,10 +8137,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
-"dgg" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "dgn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -8231,10 +8210,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "dhX" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/spawner/random/maintenance,
+/obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "dim" = (
@@ -9106,6 +9082,14 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
+"dyn" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "dyp" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
@@ -9336,6 +9320,14 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/station/commons/dorms)
+"dBF" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "dBH" = (
 /turf/open/floor/iron/white/corner{
 	dir = 1
@@ -9782,6 +9774,13 @@
 	dir = 1
 	},
 /area/station/maintenance/disposal/incinerator)
+"dLd" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "dLf" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/table/reinforced/titaniumglass,
@@ -10865,6 +10864,10 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"edW" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "eeb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12217,12 +12220,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
-"eBv" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "eBH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12290,17 +12287,6 @@
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)
-"eCD" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/gloves/color/fyellow{
-	pixel_y = 7
-	},
-/obj/structure/fluff/broken_canister_frame,
-/obj/machinery/camera/autoname/directional/north,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plating,
-/area/station/commons/storage/tools)
 "eDh" = (
 /obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/engine,
@@ -12409,6 +12395,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/equipment)
+"eFi" = (
+/obj/structure/frame/machine,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "eFk" = (
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12658,13 +12648,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"eIN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "eJe" = (
 /obj/effect/turf_decal/tile/dark_red/half/contrasted,
 /turf/open/floor/iron/smooth,
@@ -13222,6 +13205,14 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/grimy,
 /area/station/science/cubicle)
+"eTq" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "eTr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13536,6 +13527,9 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"fay" = (
+/turf/open/floor/tram,
+/area/station/security/tram)
 "faB" = (
 /obj/structure/table/wood,
 /obj/item/book/bible,
@@ -13645,6 +13639,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"fbX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/fluff/tram_rail/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "fca" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -14036,20 +14039,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"fkN" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "fkT" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/alien/weeds,
@@ -14373,6 +14362,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"fqT" = (
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 8
+	},
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "frf" = (
 /obj/structure/table/glass,
 /obj/item/defibrillator/loaded{
@@ -14618,6 +14616,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/stone,
 /area/station/command/heads_quarters/hos)
+"fuk" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "fun" = (
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15363,12 +15367,6 @@
 "fEC" = (
 /turf/closed/wall,
 /area/station/maintenance/port/lesser)
-"fEL" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/tram,
-/area/station/security/tram)
 "fEV" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/computer/security/telescreen/minisat{
@@ -16318,15 +16316,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
-"fVC" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/tram,
-/area/station/security/tram)
 "fVG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -16347,6 +16336,12 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"fWh" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "fWr" = (
 /obj/structure/closet/crate,
 /obj/structure/barricade/wooden/crude,
@@ -16420,13 +16415,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
-"fXt" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "fXJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -17027,10 +17015,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "gjr" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/spawner/random/structure/girder,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "gjL" = (
@@ -17646,6 +17633,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"gwh" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "gwo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -18784,6 +18777,17 @@
 	},
 /turf/open/floor/plating/rust,
 /area/station/maintenance/department/engine/atmos)
+"gQx" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/fyellow{
+	pixel_y = 7
+	},
+/obj/structure/fluff/broken_canister_frame,
+/obj/machinery/camera/autoname/directional/north,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plating,
+/area/station/commons/storage/tools)
 "gQG" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/closet/crate,
@@ -18973,6 +18977,12 @@
 /obj/structure/thermoplastic/light,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
+"gTC" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/turf/open/floor/tram,
+/area/station/security/tram)
 "gTH" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -20191,6 +20201,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
+"hmB" = (
+/obj/effect/landmark/transport/nav_beacon/tram/platform/birdshot/maint_right,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "hmQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
@@ -21288,12 +21302,6 @@
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"hFM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "hFO" = (
 /obj/structure/broken_flooring/corner/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -21980,18 +21988,21 @@
 /obj/item/radio/off,
 /turf/open/floor/iron/smooth,
 /area/station/command/gateway)
-"hUO" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/item/stack/sheet/mineral/titanium,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "hUP" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"hUT" = (
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/rock/pile/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/turf/open/misc/sandy_dirt,
+/area/station/security/tram)
 "hVb" = (
 /obj/machinery/plate_press,
 /obj/effect/turf_decal/stripes/line,
@@ -23076,6 +23087,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/meeting_room)
+"ipn" = (
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "ips" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -23326,6 +23341,14 @@
 "itb" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"itv" = (
+/obj/structure/transport/linear/tram,
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/thermoplastic,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "itw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -23410,6 +23433,14 @@
 /obj/machinery/power/apc/worn_out/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
+"ius" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "iut" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23645,12 +23676,8 @@
 /turf/open/floor/plating,
 /area/station/security/brig/entrance)
 "iyk" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/structure/frame/computer{
-	dir = 4
-	},
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "iyq" = (
@@ -23797,6 +23824,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
+"iBV" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "iBZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -24526,12 +24560,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
-"iPw" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/spawner/random/structure/girder,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "iPF" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -24591,6 +24619,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
+"iRp" = (
+/obj/structure/transport/linear/tram,
+/obj/effect/landmark/transport/transport_id/birdshot/line_1,
+/obj/structure/thermoplastic,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "iRv" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -24976,6 +25010,10 @@
 /obj/effect/spawner/random/armory/e_gun,
 /turf/open/floor/iron/dark/small,
 /area/station/ai_monitored/security/armory)
+"iYh" = (
+/obj/structure/fluff/broken_canister_frame,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "iYj" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tracking_beacon,
@@ -25394,7 +25432,7 @@
 /area/station/maintenance/fore/greater)
 "jfX" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+	dir = 6
 	},
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
@@ -25586,14 +25624,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/commons)
-"jku" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/thermoplastic,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "jkw" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/table/greyscale,
@@ -26172,7 +26202,8 @@
 /area/station/maintenance/starboard/aft)
 "jwC" = (
 /obj/structure/transport/linear/tram,
-/obj/effect/landmark/transport/transport_id/birdshot/line_2,
+/obj/effect/landmark/transport/nav_beacon/tram/nav/birdshot/maint,
+/obj/effect/landmark/transport/nav_beacon/tram/platform/birdshot/maint_left,
 /obj/structure/thermoplastic/light,
 /turf/open/floor/tram,
 /area/station/maintenance/port/aft)
@@ -26701,8 +26732,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "jEX" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "jEZ" = (
@@ -26752,10 +26785,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/aft)
-"jFz" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "jFB" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -27296,6 +27325,24 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/primary/central/fore)
+"jNZ" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/machinery/requests_console/directional/west{
+	department = "Ordnance Test Range";
+	name = "Test Range Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "jOb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -27605,10 +27652,6 @@
 /obj/item/instrument/harmonica,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
-"jUC" = (
-/obj/structure/frame/machine,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "jUN" = (
 /obj/structure/transport/linear/tram,
 /obj/structure/tram,
@@ -27639,6 +27682,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"jVX" = (
+/obj/structure/transport/linear/tram,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/structure/fluff/tram_rail/floor{
+	dir = 1
+	},
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "jWd" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/random/fullysynthetic,
@@ -27801,6 +27855,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "jYd" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
 /turf/open/floor/tram,
 /area/station/security/tram)
 "jYr" = (
@@ -28117,8 +28174,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "kef" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/frame/machine,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "kel" = (
@@ -28361,6 +28420,20 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"kjn" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "kjw" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -28798,11 +28871,8 @@
 /turf/closed/wall,
 /area/station/ai_monitored/aisat/exterior)
 "kqZ" = (
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 8
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
 	},
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
@@ -28943,9 +29013,9 @@
 /area/station/engineering/gravity_generator)
 "ksL" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 6
+	dir = 5
 	},
-/obj/effect/spawner/random/structure/girder,
+/obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "ksN" = (
@@ -29060,6 +29130,11 @@
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"kvb" = (
+/obj/structure/transport/linear/tram,
+/obj/structure/thermoplastic,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "kvf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -29086,13 +29161,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"kvN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "kvO" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/camera/directional/east{
@@ -29198,10 +29266,10 @@
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/fore/lesser)
-"kyk" = (
-/obj/item/stack/sheet/mineral/titanium,
+"kye" = (
+/obj/effect/landmark/transport/nav_beacon/tram/platform/birdshot/prison_wing,
 /turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
+/area/station/security/tram)
 "kyr" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/airalarm/directional/west,
@@ -29465,12 +29533,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"kDa" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "kDg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -29902,7 +29964,10 @@
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
 "kKy" = (
-/obj/structure/frame/machine,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "kKB" = (
@@ -30018,6 +30083,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/small,
 /area/station/maintenance/department/medical/central)
+"kNA" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/tram,
+/area/station/security/tram)
 "kND" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison)
@@ -32356,15 +32430,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/aft)
-"lBa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/fluff/tram_rail/end{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "lBf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -32442,12 +32507,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
-"lCi" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/turf/open/floor/tram,
-/area/station/security/tram)
 "lCt" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -32606,15 +32665,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"lFH" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/tram,
-/area/station/security/tram)
 "lGe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33517,13 +33567,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
-"lUA" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "lUE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34545,24 +34588,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"mmf" = (
-/obj/structure/table,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/assembly/timer{
-	pixel_y = 7
-	},
-/obj/machinery/light_switch/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "mmi" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -34849,6 +34874,25 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
+"mtk" = (
+/obj/structure/table,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/assembly/timer{
+	pixel_y = 7
+	},
+/obj/machinery/light_switch/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "mtu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35555,15 +35599,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"mFD" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/rock/pile/style_random,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/turf/open/misc/sandy_dirt,
-/area/station/security/tram)
 "mFG" = (
 /obj/machinery/telecomms/processor/preset_four,
 /obj/effect/decal/cleanable/dirt,
@@ -35618,6 +35653,13 @@
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
+"mGQ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/frame/machine,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "mGT" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -35670,7 +35712,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/button/transport/tram/directional/north{
 	specific_transport_id = "bird_1";
-	id = 2
+	id = 1
 	},
 /obj/machinery/transport/destination_sign/indicator/directional/north,
 /turf/open/floor/noslip,
@@ -36250,17 +36292,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"mSM" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/fluff/tram_rail/floor{
-	dir = 1
-	},
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/right{
-	dir = 1
-	},
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "mTd" = (
 /obj/structure/closet/crate{
 	name = "Starups Clothing Crate"
@@ -36469,12 +36500,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/lower)
-"mWh" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/turf/open/floor/tram,
-/area/station/security/tram)
 "mWk" = (
 /obj/structure/cable,
 /obj/item/storage/bag/trash,
@@ -36818,9 +36843,9 @@
 /area/station/maintenance/central/greater)
 "ndA" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+	dir = 1
 	},
-/obj/item/stack/sheet/mineral/titanium,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "ndM" = (
@@ -36856,10 +36881,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/commons/vacant_room/commissary)
-"neN" = (
-/obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
-/turf/closed/wall,
-/area/station/maintenance/port/aft)
 "neZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37347,12 +37368,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/spacebridge)
-"nnW" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "noe" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -37818,12 +37833,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"nwf" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/turf/open/floor/tram,
-/area/station/security/tram)
 "nwg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -38628,6 +38637,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/maintenance/solars/starboard/fore)
+"nJm" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "nJx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38744,13 +38760,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"nLg" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "nLN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -39461,6 +39470,14 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
+"oaE" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "oaV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39516,6 +39533,13 @@
 "ocb" = (
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
+"ocg" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "ocs" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -40818,6 +40842,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"oBo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "oBA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -41352,14 +41382,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
-"oMD" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "oMF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
@@ -41376,12 +41398,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/small,
 /area/station/medical/storage)
-"oNk" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
-	},
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "oNn" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -41498,13 +41514,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"oPa" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/item/stack/sheet/mineral/titanium,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "oPc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/computer/upload/borg{
@@ -41860,6 +41869,18 @@
 /obj/structure/broken_flooring/singular/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"oVE" = (
+/obj/structure/flora/bush/large/style_random{
+	pixel_x = -18;
+	pixel_y = -9
+	},
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/turf/open/misc/sandy_dirt,
+/area/station/security/tram)
 "oVK" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -41927,13 +41948,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "oXh" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
 /obj/structure/transport/linear/tram,
-/obj/structure/tram,
+/obj/structure/fluff/tram_rail/floor{
+	dir = 1
+	},
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/right{
+	dir = 1
+	},
 /turf/open/floor/tram,
-/area/station/security/tram)
+/area/station/maintenance/port/aft)
 "oXs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
@@ -42408,6 +42432,16 @@
 	dir = 8
 	},
 /area/station/service/bar/backroom)
+"pfY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "pgh" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/table/reinforced/titaniumglass,
@@ -42623,12 +42657,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"pjI" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "pjL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -43018,6 +43046,9 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/space/basic,
 /area/space)
+"pqf" = (
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "pqm" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tcomms)
@@ -43096,11 +43127,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "prT" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/white/line,
 /obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "prW" = (
@@ -43415,6 +43443,13 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
+"pwG" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "pwJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43864,6 +43899,15 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
+"pDG" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "pDQ" = (
 /obj/structure/cable,
 /obj/structure/table/glass,
@@ -43992,10 +44036,6 @@
 /obj/machinery/door/window/brigdoor/right/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
-"pGh" = (
-/obj/structure/fluff/broken_canister_frame,
-/turf/open/floor/plating,
-/area/station/maintenance/department/bridge)
 "pGp" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -44448,6 +44488,13 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/corporate_showroom)
+"pNm" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "pNy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -44475,6 +44522,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/small,
 /area/station/science/lab)
+"pNT" = (
+/obj/structure/transport/linear/tram,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/fluff/tram_rail/floor{
+	dir = 1
+	},
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "pOb" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -44483,13 +44541,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"pOe" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "pOg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45619,6 +45670,17 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"qfw" = (
+/obj/structure/transport/linear/tram,
+/obj/structure/fluff/tram_rail/floor{
+	dir = 1
+	},
+/obj/structure/thermoplastic,
+/obj/structure/chair/sofa/bench/tram/left{
+	dir = 1
+	},
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "qfz" = (
 /obj/item/kirbyplants/organic/applebush,
 /obj/machinery/light/small/directional/south,
@@ -45900,28 +45962,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"qiH" = (
-/obj/structure/table,
-/obj/machinery/airalarm/directional/west,
-/obj/item/pipe_dispenser,
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = 13
-	},
-/obj/item/transfer_valve{
-	pixel_x = 10;
-	pixel_y = 21
-	},
-/obj/item/transfer_valve{
-	pixel_x = 7;
-	pixel_y = 19
-	},
-/obj/item/transfer_valve{
-	pixel_x = 4;
-	pixel_y = 17
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "qiM" = (
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
@@ -46265,13 +46305,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
-"qnK" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "qnL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -46616,6 +46649,15 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
+"quQ" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/tram,
+/area/station/security/tram)
 "quS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46844,10 +46886,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/rust,
 /area/station/maintenance/fore/lesser)
-"qyI" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "qyN" = (
 /obj/structure/railing,
 /turf/open/space/basic,
@@ -47579,14 +47617,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/cafeteria)
-"qKH" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "qKI" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/small,
@@ -47830,6 +47860,18 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/cargo/drone_bay)
+"qOO" = (
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
+"qOT" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "qPc" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -47840,12 +47882,6 @@
 "qPN" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/safe)
-"qQd" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "qQg" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -48269,11 +48305,7 @@
 /turf/open/floor/wood,
 /area/station/cargo/boutique)
 "qWd" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/structure/girder,
+/obj/structure/frame/machine,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "qWh" = (
@@ -49255,6 +49287,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/cargo/boutique)
+"rlV" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/turf/open/floor/tram,
+/area/station/security/tram)
 "rma" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 6
@@ -49533,6 +49574,12 @@
 	},
 /turf/open/floor/glass,
 /area/station/hallway/secondary/spacebridge)
+"rrB" = (
+/obj/structure/transport/linear/tram,
+/obj/effect/landmark/transport/transport_id/birdshot/line_2,
+/obj/structure/thermoplastic/light,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "rrC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49719,14 +49766,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/science/lower)
-"rup" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "ruC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
@@ -51148,6 +51187,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/pharmacy)
+"rQM" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "rQN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -51709,6 +51756,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/flat_white,
 /area/station/science/robotics/augments)
+"rZk" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/transport/linear/tram,
+/obj/structure/thermoplastic,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "rZn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -52526,20 +52579,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"smM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "smV" = (
 /obj/structure/chair{
 	dir = 4
@@ -52913,12 +52952,6 @@
 /obj/item/stock_parts/subspace/filter,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
-"ssK" = (
-/obj/structure/transport/linear/tram,
-/obj/effect/landmark/transport/transport_id/birdshot/line_1,
-/obj/structure/thermoplastic,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "ssY" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -55207,6 +55240,15 @@
 /obj/item/clipboard,
 /turf/open/floor/iron/white/small,
 /area/station/science/server)
+"tfY" = (
+/obj/structure/transport/linear/tram,
+/obj/structure/fluff/tram_rail/floor{
+	dir = 1
+	},
+/obj/structure/thermoplastic,
+/obj/structure/rack,
+/turf/open/floor/tram,
+/area/station/maintenance/port/aft)
 "tgj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/easel,
@@ -55482,20 +55524,6 @@
 "tnb" = (
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
-"tno" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/machinery/requests_console/directional/west{
-	department = "Ordnance Test Range";
-	name = "Test Range Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "tns" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
@@ -56535,19 +56563,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"tDM" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "rdordnance";
-	name = "Ordnance Lab Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/science/ordnance)
 "tDP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57616,13 +57631,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
-"tWJ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "tWL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue{
@@ -58089,6 +58097,14 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/security/brig/entrance)
+"udE" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "udI" = (
 /obj/structure/closet{
 	name = "Evidence Closet 3"
@@ -58904,17 +58920,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/hallway/secondary/dock)
-"urI" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/obj/machinery/computer/tram_controls{
-	specific_transport_id = "bird_2"
-	},
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "urM" = (
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -60317,8 +60322,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/port/aft)
 "uRp" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/structure/girder,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/tram,
 /area/station/security/tram)
 "uRF" = (
@@ -60414,16 +60421,6 @@
 	},
 /turf/open/floor/iron/textured_half,
 /area/station/commons/storage/art)
-"uTd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "uTh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/opposingcorners,
@@ -60633,6 +60630,20 @@
 "uWo" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
+"uWu" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/holosign/barrier/atmos/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "uWv" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -61173,13 +61184,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/station/science/robotics/mechbay)
-"vfJ" = (
-/obj/structure/transport/linear/tram,
-/obj/effect/landmark/transport/nav_beacon/tram/nav/birdshot/maint,
-/obj/effect/landmark/transport/nav_beacon/tram/platform/birdshot/maint_left,
-/obj/structure/thermoplastic/light,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "vfK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -62060,6 +62064,34 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"vrW" = (
+/obj/structure/table,
+/obj/machinery/airalarm/directional/west,
+/obj/item/pipe_dispenser{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 13
+	},
+/obj/item/transfer_valve{
+	pixel_x = 10;
+	pixel_y = 21
+	},
+/obj/item/transfer_valve{
+	pixel_x = 7;
+	pixel_y = 19
+	},
+/obj/item/transfer_valve{
+	pixel_x = 4;
+	pixel_y = 17
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "vrY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63850,12 +63882,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
-"vVp" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "vVw" = (
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -64420,7 +64446,9 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "weV" = (
-/obj/effect/landmark/transport/nav_beacon/tram/platform/birdshot/prison_wing,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
 /turf/open/floor/tram,
 /area/station/security/tram)
 "wfa" = (
@@ -64474,9 +64502,8 @@
 /area/station/science/research)
 "wfH" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+	dir = 9
 	},
-/obj/item/stack/sheet/mineral/titanium,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "wfP" = (
@@ -65285,13 +65312,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
-"wte" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "wtm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/blue{
@@ -65976,7 +65996,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "wDu" = (
-/obj/effect/landmark/transport/nav_beacon/tram/platform/birdshot/maint_right,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/tram,
 /area/station/maintenance/department/medical/central)
 "wDA" = (
@@ -66215,6 +66235,13 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/spacebridge)
+"wHY" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "wIc" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/flora/rock/pile/jungle/style_random,
@@ -67125,17 +67152,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"wUf" = (
-/obj/structure/transport/linear/tram,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/structure/fluff/tram_rail/floor{
-	dir = 1
-	},
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/maintenance/port/aft)
 "wUZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -68768,7 +68784,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/button/transport/tram/directional/north{
 	specific_transport_id = "bird_1";
-	id = 1
+	id = 2
 	},
 /obj/machinery/transport/destination_sign/indicator/directional/north,
 /turf/open/floor/noslip,
@@ -69197,13 +69213,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"xwP" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "xwQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -69676,6 +69685,13 @@
 	},
 /turf/open/floor/iron/small,
 /area/station/hallway/primary/starboard)
+"xDM" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/item/stack/sheet/mineral/titanium,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "xDW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69837,6 +69853,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"xGb" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/transport/linear/tram,
+/obj/structure/tram,
+/turf/open/floor/tram,
+/area/station/security/tram)
 "xGc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70223,14 +70245,6 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
-"xKZ" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/floor/tram,
-/area/station/security/tram)
 "xLc" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -70827,18 +70841,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
-"xSL" = (
-/obj/structure/flora/bush/large/style_random{
-	pixel_x = -18;
-	pixel_y = -9
-	},
-/obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/turf/open/misc/sandy_dirt,
-/area/station/security/tram)
 "xSO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -71578,6 +71580,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"ycv" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/tram,
+/area/station/maintenance/department/medical/central)
 "ycC" = (
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
@@ -71887,9 +71896,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
-"ygs" = (
-/turf/open/floor/tram,
-/area/station/maintenance/department/medical/central)
 "ygu" = (
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
@@ -72003,6 +72009,10 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"yhE" = (
+/obj/effect/landmark/transport/nav_beacon/tram/nav/immovable_rod,
+/turf/closed/wall,
+/area/station/maintenance/port/aft)
 "yhF" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -84572,12 +84582,12 @@ vKU
 lPO
 vfc
 lzM
-nLg
-eIN
-xwP
-eIN
-aWy
-tWJ
+jfX
+cJu
+kKy
+cJu
+uRp
+kef
 ieZ
 rtQ
 aJq
@@ -84829,12 +84839,12 @@ dkI
 dLn
 rxu
 lzM
-jfX
-kKy
-kKy
-cJu
-uRp
-kef
+ndA
+qWd
+qWd
+dhX
+iyk
+ays
 ieZ
 rtQ
 aJq
@@ -85086,12 +85096,12 @@ qBT
 uRJ
 rcg
 lzM
-ndA
-qWd
+xDM
+acO
 kLG
-dhX
-iyk
-ays
+bQz
+rlV
+wHY
 ieZ
 rtQ
 aJq
@@ -85614,11 +85624,11 @@ nlV
 toT
 kaI
 tlI
-mFD
+hUT
 uEI
 gxx
 gxx
-xSL
+oVE
 jYv
 nlV
 sGp
@@ -85857,12 +85867,12 @@ mZc
 hXU
 hXU
 aFR
-cum
-bOQ
-bOQ
-bOQ
-bOQ
-qKH
+oaE
+dyn
+dyn
+dyn
+dyn
+qOT
 aFR
 kGC
 qBi
@@ -85884,12 +85894,12 @@ qBi
 qBi
 ltp
 qBi
-nwf
-fEL
-pOe
-fEL
-fEL
-lCi
+gTC
+weV
+jEX
+weV
+weV
+jYd
 qBi
 xAG
 pGR
@@ -86114,12 +86124,12 @@ ccD
 yap
 lzM
 ezE
-xKZ
-eBv
-jEX
-jEX
-jku
-nnW
+ius
+rZk
+kvb
+kvb
+itv
+xGb
 aFR
 kGC
 qBi
@@ -86141,12 +86151,12 @@ qBi
 qBi
 ltp
 qBi
-mWh
-jYd
-jYd
-jYd
-jYd
-dgg
+aYO
+fay
+fay
+fay
+fay
+ipn
 qBi
 xAG
 pGR
@@ -86373,37 +86383,37 @@ lzM
 aFR
 hYz
 gkO
-ssK
+iRp
 aPe
-jEX
+kvb
 jUN
-fVC
-smM
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fVC
-fkN
-lFH
-jYd
-jYd
-jYd
-weV
-jYd
-jYd
+kNA
+uWu
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kNA
+kjn
+quQ
+fay
+fay
+fay
+kye
+fay
+fay
 qBi
 iJt
 pGR
@@ -86629,9 +86639,9 @@ eWB
 lzM
 aFR
 vNj
-eBv
-jEX
-jEX
+rZk
+kvb
+kvb
 kSo
 kyS
 aFR
@@ -86655,12 +86665,12 @@ qBi
 qBi
 ltp
 qBi
-mWh
-jYd
-jYd
-jYd
-jYd
-dgg
+aYO
+fay
+fay
+fay
+fay
+ipn
 qBi
 xAG
 pSd
@@ -86886,10 +86896,10 @@ vzY
 lzM
 aFR
 ryj
-oXh
+eTq
 cID
 cID
-oXh
+eTq
 gXd
 aFR
 kGC
@@ -87142,7 +87152,7 @@ tRE
 dUD
 lzM
 lzM
-mId
+xrh
 tpm
 jeh
 jeh
@@ -87169,7 +87179,7 @@ mTQ
 qDO
 lzM
 lzM
-xrh
+mId
 tpm
 jeh
 jeh
@@ -88699,7 +88709,7 @@ trp
 trp
 trp
 trp
-neN
+yhE
 trp
 trp
 trp
@@ -88957,7 +88967,7 @@ hQE
 xAR
 fos
 xAR
-lBa
+fbX
 xAR
 xAR
 xAR
@@ -89214,8 +89224,8 @@ trp
 eVe
 pxs
 upR
-cWb
-rup
+jVX
+rQM
 vJH
 xAR
 trp
@@ -89471,8 +89481,8 @@ trp
 qVz
 sdC
 eEl
-cHt
-kDa
+qfw
+fuk
 vJH
 xAR
 trp
@@ -89629,7 +89639,7 @@ ueX
 slY
 slY
 slY
-eCD
+gQx
 hbv
 rkr
 hmj
@@ -89728,8 +89738,8 @@ fAr
 oNM
 qOv
 eEl
-mSM
-kDa
+oXh
+fuk
 vJH
 xAR
 trp
@@ -89984,9 +89994,9 @@ xul
 mxM
 iaZ
 cSD
-jwC
-crV
-kDa
+rrB
+tfY
+fuk
 vJH
 xAR
 trp
@@ -90241,9 +90251,9 @@ nFu
 mxM
 gTk
 cSD
-vfJ
-crV
-kDa
+jwC
+tfY
+fuk
 vJH
 xAR
 trp
@@ -90496,11 +90506,11 @@ gEe
 bbU
 knJ
 fAr
-urI
+cwd
 qOv
 eEl
-cHt
-kDa
+qfw
+fuk
 vJH
 xAR
 trp
@@ -90756,8 +90766,8 @@ trp
 qVz
 sdC
 eEl
-mSM
-kDa
+oXh
+fuk
 vJH
 xAR
 trp
@@ -91013,8 +91023,8 @@ trp
 vez
 isf
 oGS
-wUf
-oMD
+pNT
+dBF
 trp
 vfi
 trp
@@ -91269,7 +91279,7 @@ xul
 trp
 vJH
 vJH
-lUA
+iBV
 vJH
 vJH
 trp
@@ -91783,7 +91793,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -92040,7 +92050,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -92297,7 +92307,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -92554,7 +92564,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -92811,7 +92821,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -93068,7 +93078,7 @@ blb
 blb
 blb
 blb
-wte
+pwG
 blb
 blb
 blb
@@ -93325,7 +93335,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -93582,7 +93592,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -93839,7 +93849,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -94096,7 +94106,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -94353,7 +94363,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -94610,7 +94620,7 @@ blb
 blb
 blb
 blb
-wte
+pwG
 blb
 blb
 blb
@@ -94867,7 +94877,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -95124,7 +95134,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -95381,7 +95391,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -95638,7 +95648,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -95895,7 +95905,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -96064,7 +96074,7 @@ trk
 kjU
 izL
 iLV
-pGh
+iYh
 lZt
 lZt
 xYO
@@ -96152,7 +96162,7 @@ blb
 blb
 blb
 blb
-wte
+pwG
 blb
 blb
 blb
@@ -96409,7 +96419,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -96666,7 +96676,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -96923,7 +96933,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -97180,7 +97190,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -97437,7 +97447,7 @@ blb
 blb
 blb
 blb
-wte
+pwG
 blb
 blb
 blb
@@ -97694,7 +97704,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -97951,7 +97961,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -98208,7 +98218,7 @@ blb
 dDB
 dDB
 dDB
-wte
+pwG
 dDB
 dDB
 bSo
@@ -98465,7 +98475,7 @@ blb
 sSQ
 lMF
 lMF
-uTd
+pfY
 lMF
 lMF
 sSQ
@@ -98722,7 +98732,7 @@ sSQ
 sSQ
 ulO
 ulO
-ase
+ycv
 ulO
 ulO
 sSQ
@@ -98978,10 +98988,10 @@ sqV
 nFy
 sSQ
 liU
-bGm
+fWh
+fqT
+fWh
 kqZ
-bGm
-qQd
 sSQ
 rwq
 sSQ
@@ -99235,10 +99245,10 @@ aTc
 frB
 sSQ
 qDD
-ygs
-ygs
-ygs
-jFz
+pqf
+pqf
+pqf
+wDu
 ulO
 gpu
 sSQ
@@ -99492,17 +99502,17 @@ liH
 uOw
 eBQ
 qDD
-ygs
-ygs
-ygs
-jFz
+pqf
+pqf
+pqf
+wDu
 ulO
 gpu
 sOj
 vTG
+crr
+cuG
 ksL
-kvN
-oPa
 sSQ
 dDB
 dDB
@@ -99749,17 +99759,17 @@ ewW
 aTc
 cku
 qDD
-ygs
-ygs
-ygs
-jFz
+pqf
+pqf
+pqf
+wDu
 ulO
 gpu
 sOj
 vTG
+ocg
+pqf
 gjr
-ygs
-iPw
 sSQ
 dDB
 dDB
@@ -100006,17 +100016,17 @@ oZY
 aTc
 cku
 qDD
-ygs
+pqf
+hmB
+pqf
 wDu
-ygs
-jFz
 ulO
 gpu
 sOj
 vTG
+udE
+edW
 prT
-qyI
-bVC
 sSQ
 dDB
 dDB
@@ -100263,17 +100273,17 @@ hia
 ggl
 eBQ
 qDD
-ygs
-ygs
-ygs
-jFz
+pqf
+pqf
+pqf
+wDu
 ulO
 gpu
 sOj
 vTG
+pDG
+qOO
 dbO
-kyk
-vVp
 sSQ
 dDB
 dDB
@@ -100520,17 +100530,17 @@ fWW
 idW
 sSQ
 qDD
-ygs
-ygs
-ygs
-jFz
+pqf
+pqf
+pqf
+wDu
 ulO
 gpu
 sOj
 vTG
-fXt
-jUC
-bVC
+pNm
+eFi
+prT
 sSQ
 dDB
 dDB
@@ -100777,17 +100787,17 @@ lQZ
 sSQ
 sSQ
 ugY
-pjI
-pjI
-pjI
-oNk
+gwh
+gwh
+gwh
+wfH
 ulO
 gpu
 sOj
 vTG
-qnK
-ygs
-bVC
+nJm
+pqf
+prT
 sSQ
 dDB
 dDB
@@ -101042,9 +101052,9 @@ ulO
 gpu
 sOj
 vTG
+mGQ
+edW
 bFG
-qyI
-hUO
 sSQ
 dDB
 dDB
@@ -101299,9 +101309,9 @@ ulO
 gpu
 sOj
 vTG
+dLd
+gwh
 wfH
-pjI
-oNk
 sSQ
 blb
 blb
@@ -107717,7 +107727,7 @@ vbR
 vbR
 vbR
 hzI
-hFM
+oBo
 vbR
 vbR
 fnz
@@ -121296,7 +121306,7 @@ qJr
 qJr
 fky
 lkV
-tDM
+cDg
 okW
 kQt
 fUo
@@ -123603,9 +123613,9 @@ rle
 wTJ
 wrv
 ejx
-tno
-qiH
-mmf
+jNZ
+vrW
+mtk
 qei
 xwQ
 wCH


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24418
Original PR: https://github.com/tgstation/tgstation/pull/79056
--------------------

## About The Pull Request

Fixes #79003

I've added a couple of useful tools to Birdshot's ordnance lab - a second RPD, and two holofan projectors. 

![image](https://github.com/tgstation/tgstation/assets/105025397/8024799a-39e5-461f-9450-912a758f9673)

I also removed one (1) cable from under the reinforced window by ordnance's front door. I didn't touch the other electrified windows in the science wing.
## Why It's Good For The Game

The extra RPD lets two people comfortably work in ordnance, like they can on most maps, and the holofan projectors allow changes to be made to the burn or freeze chambers without disaster. Most other maps have these things available, so it seems reasonable to add them here.

As pointed out in #79003, a quick toxins moment is all it takes for the modified window to explode, and for the pressure to slam an unfortunate spaceman into an electrified grille until they die. This feels excessive to me, and the other ordnance windows aren't electrified - so I took the cable out.
## Changelog
:cl: lizardqueenlexi
qol: Birdshot ordnance is now equipped with a second RPD and two holofan projectors.
qol: Ordnance mishaps on Birdshot are significantly less likely to slam you into an electrified window until you die.
/:cl:
