### PR TITLE
[TG Mirror] Spasms don't trigger in stasis or otherwise 

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -604,7 +604,7 @@
 	alert_type = null
 
 /datum/status_effect/spasms/tick(seconds_between_ticks)
-	if(owner.stat >= UNCONSCIOUS)
+	if(owner.stat >= UNCONSCIOUS || owner.incapacitated() || HAS_TRAIT(owner, TRAIT_HANDS_BLOCKED) || HAS_TRAIT(owner, TRAIT_IMMOBILIZED))
 		return
 	if(!prob(15))
 		return
@@ -614,8 +614,6 @@
 				to_chat(owner, span_warning("Your leg spasms!"))
 				step(owner, pick(GLOB.cardinals))
 		if(2)
-			if(owner.incapacitated())
-				return
 			var/obj/item/held_item = owner.get_active_held_item()
 			if(!held_item)
 				return
@@ -644,8 +642,6 @@
 			owner.ClickOn(owner)
 			owner.set_combat_mode(FALSE)
 		if(5)
-			if(owner.incapacitated())
-				return
 			var/obj/item/held_item = owner.get_active_held_item()
 			var/list/turf/targets = list()
 			for(var/turf/nearby_turfs in oview(owner, 3))


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24428
Original PR: https://github.com/tgstation/tgstation/pull/79065
--------------------
## About The Pull Request

Fixes #77333 

Spasms don't trigger if you are incapacitated (including in stasis), your hands are blocked, or you are immobilized. 

## Why It's Good For The Game

Consistency. Mutations and brain traumas don't fire on-life due to stasis (which are both how you acquire spasms). Otherwise it shouldn't bother triggering if you can't actually... spasm at the moment. 

## Changelog

:cl:  Melbert
fix: Spasms won't trigger in stasis, incapacitated, if your hands are blocked, or you are immobilized. 
/:cl:

