### PR TITLE
[Skyrat Mirror] [MODULAR] You can now rename and describe any loadout item, not just plushies.

### DIFF
--- a/code/__DEFINES/~skyrat_defines/loadouts.dm
+++ b/code/__DEFINES/~skyrat_defines/loadouts.dm
@@ -16,6 +16,7 @@
 
 #define INFO_GREYSCALE "greyscale"
 #define INFO_NAMED "name"
+#define INFO_DESCRIBED "description"
 
 /// Max amonut of misc / backpack items that are allowed.
 #define MAX_ALLOWED_MISC_ITEMS 3

--- a/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/_loadout_datum.dm
@@ -38,8 +38,8 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 /datum/loadout_item
 	/// Displayed name of the loadout item.
 	var/name
-	/// Whether this item can be renamed.
-	var/can_be_named = FALSE
+	/// Whether this item can be renamed and described.
+	var/can_be_named = TRUE
 	/// The category of the loadout item.
 	var/category
 	/// The actual item path of the loadout item.
@@ -114,12 +114,15 @@ GLOBAL_LIST_EMPTY(all_loadout_datums)
 			else
 				stack_trace("[type] on_equip_item(): Could not locate backpack item (path: [item_path]) in [equipper]'s contents to set greyscaling!")
 
-	if(can_be_named && !visuals_only && (INFO_NAMED in our_loadout[item_path]))
+	if(can_be_named && !visuals_only)
 		var/obj/item/equipped_item = locate(item_path) in equipper.get_all_gear()
 		if(equipped_item)
-			equipped_item.name = our_loadout[item_path][INFO_NAMED]
+			if(INFO_NAMED in our_loadout[item_path])
+				equipped_item.name = our_loadout[item_path][INFO_NAMED]
+			if(INFO_DESCRIBED in our_loadout[item_path])
+				equipped_item.desc = our_loadout[item_path][INFO_DESCRIBED]
 		else
-			stack_trace("[type] on_equip_item(): Could not locate item (path: [item_path]) in [equipper]'s contents to set name!")
+			stack_trace("[type] on_equip_item(): Could not locate item (path: [item_path]) in [equipper]'s contents to set name/desc!")
 
 /*
  * Called after the item is equipped on [equipper], at the end of character setup.

--- a/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_toys.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/loadout_datum_toys.dm
@@ -2,7 +2,6 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 
 /datum/loadout_item/toys
 	category = LOADOUT_ITEM_TOYS
-	can_be_named = TRUE
 
 /*
 *	PLUSHIES

--- a/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
+++ b/modular_skyrat/modules/loadouts/loadout_ui/loadout_manager.dm
@@ -208,10 +208,14 @@
 /// Set [item]'s name to input provided.
 /datum/loadout_manager/proc/set_item_name(datum/loadout_item/item)
 	var/current_name = ""
+	var/current_desc = ""
 	if(INFO_NAMED in owner.prefs.loadout_list[item.item_path])
 		current_name = owner.prefs.loadout_list[item.item_path][INFO_NAMED]
+	if(INFO_DESCRIBED in owner.prefs.loadout_list[item.item_path])
+		current_desc = owner.prefs.loadout_list[item.item_path][INFO_DESCRIBED]
 
-	var/input_name = stripped_input(owner, "What name do you want to give [item.name]? Leave blank to clear.", "[item.name] name", current_name, MAX_NAME_LEN)
+	var/input_name = tgui_input_text(owner, "What name do you want to give [item.name]? Leave blank to clear.", "[item.name] name", current_name, MAX_NAME_LEN)
+	var/input_desc = tgui_input_text(owner, "What description do you want to give [item.name]? 256 character max, leave blank to clear.", "[item.name] description", current_desc, 256, multiline = TRUE)
 	if(QDELETED(src) || QDELETED(owner) || QDELETED(owner.prefs))
 		return
 
@@ -224,6 +228,11 @@
 	else
 		if(INFO_NAMED in owner.prefs.loadout_list[item.item_path])
 			owner.prefs.loadout_list[item.item_path] -= INFO_NAMED
+	if(input_desc)
+		owner.prefs.loadout_list[item.item_path][INFO_DESCRIBED] = input_desc
+	else
+		if(INFO_DESCRIBED in owner.prefs.loadout_list[item.item_path])
+			owner.prefs.loadout_list[item.item_path] -= INFO_DESCRIBED
 
 /datum/loadout_manager/proc/display_job_restrictions(datum/loadout_item/item)
 	if(!length(item.restricted_roles))


### PR DESCRIPTION
## **Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24288**
## About The Pull Request

You can now rename and describe any loadout item, not just plushies.

## How This Contributes To The Skyrat Roleplay Experience

Lets players customize their clothing and stuff more. Fun flavor!

## Proof of Testing

https://github.com/Skyrat-SS13/Skyrat-tg/assets/4081722/94d50a00-8352-47d2-94b4-411df58cb5bb

## Changelog


:cl: Iamgoofball
qol: You can now rename and describe any loadout item, not just plushies.
/:cl:
