### PR TITLE
[TG Mirror] Tints the screen for halloween 

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -79,6 +79,10 @@
 /atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(GRAVITY_PULSE_RENDER_TARGET, offset), size = 10))
+	if(check_holidays(HALLOWEEN))
+		// Makes things a tad greyscale (leaning purple) and drops low colors for vibes
+		// We're basically using alpha as better constant here btw
+		add_filter("spook_color", 2, color_matrix_filter(list(0.75,0.13,0.13,0, 0.13,0.7,0.13,0, 0.13,0.13,0.75,0, -0.06,-0.09,-0.08,1, 0,0,0,0)))
 
 // Blackness renders weird when you view down openspace, because of transforms and borders and such
 // This is a consequence of not using lummy's grouped transparency, but I couldn't get that to work without totally fucking up


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24438
Original PR: https://github.com/tgstation/tgstation/pull/79062
--------------------
## About The Pull Request

Adds a color matrix to the game plate on halloween that greyscales slightly and dims/drops dim colors for a harsher dropoff
I'm not sure the dropoff is strong enough, can't decide.

## Why It's Good For The Game

![276023326-205a3068-4f6c-4531-bc19-a3bb1f9f3a5e](https://github.com/tgstation/tgstation/assets/58055496/d6b3bd89-96a3-4da1-9d45-eac91f130c25)

## Changelog
:cl: LemonInTheDark
add: Screen is now more grungy for halloween
/:cl:
