### PR TITLE
[TG Mirror] Ghost orbit popup double feature: Blackout drunkeness and Nar'Sie runes 

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -253,6 +253,7 @@
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
 	RegisterSignal(owner, COMSIG_ATOM_SPLASHED, PROC_REF(on_splashed))
+	notify_ghosts("[owner] is blacking out!", source = owner, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Bro I'm not even drunk right now")
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()
 	. = ..()

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -372,6 +372,8 @@
 	for(var/shielded_turf in spiral_range_turfs(1, cultist, 1))
 		LAZYADD(shields, new /obj/structure/emergency_shield/cult/narsie(shielded_turf))
 
+	notify_ghosts("[cultist] has begun scribing a Nar'Sie rune!", source = cultist, action = NOTIFY_ORBIT, header = "Maranax Infirmux!")
+
 	return TRUE
 
 /*


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24439
Original PR: https://github.com/tgstation/tgstation/pull/78982
--------------------
## About The Pull Request

This adds two new notify_ghosts popups, for Blackout Drunkeness and Nar'Sie Rune Inscription.
## Why It's Good For The Game

Nar'Sie rune inscription already has a big announcement, but no orbit prompt. It's an important enough event to warrant having one.

The blackout drunkenness period is something that deserves to have an audience.
## Changelog
:cl:  Rhials
qol: Ghosts will now be prompted to orbit when someone loses control due to being blackout drunk.
qol: Ghosts will now be prompted to orbit when a cultist begins inscribing a Nar'Sie rune.
/:cl:
