### PR TITLE
[TG Mirror] fixes oxyloss not knocking people out at 50 

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -778,15 +778,14 @@
 	check_passout()
 
 /**
-* Check to see if we should be passed out from oyxloss
+* Check to see if we should be passed out from oxyloss
 */
 /mob/living/carbon/proc/check_passout()
-	if(!isnum(oxyloss))
-		return
-	if(oxyloss <= 50)
-		if(getOxyLoss() > 50)
+	var/mob_oxyloss = getOxyLoss()
+	if(mob_oxyloss >= 50)
+		if(!HAS_TRAIT_FROM(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT))
 			ADD_TRAIT(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
-	else if(getOxyLoss() <= 50)
+	else if(mob_oxyloss < 50)
 		REMOVE_TRAIT(src, TRAIT_KNOCKEDOUT, OXYLOSS_TRAIT)
 
 /mob/living/carbon/get_organic_health()


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24442
Original PR: https://github.com/tgstation/tgstation/pull/79036
--------------------
## About The Pull Request

be it far from me to explain why the args not getting put in directly broke this, but reinserting them into the check_passout stuff from #78657 fixes it.

should close #79034 but I have no clue if other similar changes to how args were being handled might not have problems elsewhere.

## Why It's Good For The Game

atmospheric simulator, breathing mechanics good, also chems and i guess bleeding and whatnot

## Changelog

:cl: Higgin
fix: automatic breathers rejoice. oxyloss now knocks people out again.
/:cl:
