### PR TITLE
[TG Mirror] Medical beds show correct overlay  

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -90,6 +90,8 @@
 /obj/structure/bed/medical/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noisy_movement)
+	if(anchored)
+		update_appearance()
 
 /obj/structure/bed/medical/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24437
Original PR: https://github.com/tgstation/tgstation/pull/79057
--------------------
## About The Pull Request

Update the overlay if the brakes are on at mapload

## Changelog

:cl:  LT3
fix: Maploaded medical beds now have correct brake lights
/:cl:
