### PR TITLE
 Fixes a bug where your mother would delete your species after calling you a disappointment, rendering you a broken husk of a mob 

### DIFF
--- a/code/__HELPERS/dynamic_human_icon_gen.dm
+++ b/code/__HELPERS/dynamic_human_icon_gen.dm
@@ -5,6 +5,9 @@ GLOBAL_LIST_EMPTY(dynamic_human_appearances)
 /proc/get_dynamic_human_appearance(outfit_path, species_path = /datum/species/human, mob_spawn_path, r_hand, l_hand, bloody_slots = NONE, animated = TRUE)
 	if(!species_path)
 		return FALSE
+	if(!ispath(species_path))
+		stack_trace("Attempted to call get_dynamic_human_appearance() with an instantiated species_path. Pass the species datum typepath instead.")
+		return FALSE
 	var/arg_string = "[outfit_path]_[species_path]_[mob_spawn_path]_[l_hand]_[r_hand]_[bloody_slots]"
 	if(GLOB.dynamic_human_appearances[arg_string]) //if already exists in our cache, just return that
 		return GLOB.dynamic_human_appearances[arg_string]

--- a/code/modules/hallucination/mother.dm
+++ b/code/modules/hallucination/mother.dm
@@ -77,5 +77,5 @@
 /obj/effect/client_image_holder/hallucination/your_mother/Initialize(mapload, list/mobs_which_see_us, datum/hallucination/parent)
 	. = ..()
 	var/mob/living/carbon/hallucinator = parent.hallucinator
-	image_icon = getFlatIcon(get_dynamic_human_appearance(/datum/outfit/yourmother, hallucinator.dna.species))
+	image_icon = getFlatIcon(get_dynamic_human_appearance(/datum/outfit/yourmother, hallucinator.dna.species.type))
 	regenerate_image()


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24445
Original PR: https://github.com/tgstation/tgstation/pull/79098
--------------------
## About The Pull Request

Yep. So I was investigating why a player was weirdly unable to equip things, or do a lot of stuff. And encountered in the runtime logs that _their species datum was deleted_. How? Well...the answer is...your mother.

---

So the hallucination of 'your mother' uses the hallucinator's species datum to create itself here:

https://github.com/tgstation/tgstation/blob/07096ffcad0f06ac9276c38275fa4e09e7dece41/code/modules/hallucination/mother.dm#L80

Which then calls set_species, but it passes _your actual species datum in as an arg_

https://github.com/tgstation/tgstation/blob/07096ffcad0f06ac9276c38275fa4e09e7dece41/code/__HELPERS/dynamic_human_icon_gen.dm#L12

which leads to the mob _having your species datum_

https://github.com/tgstation/tgstation/blob/07096ffcad0f06ac9276c38275fa4e09e7dece41/code/datums/dna.dm#L512

Then when mother goes away and deletes herself, so does your species datum. Leaving the hallucinator extremely broken, bugged, and humiliated.

@ MrMelbert maybe letting people `set_species()` using an instantiated species datum was a mistake...lol. 

## Why It's Good For The Game

Nerfs your mother. She is too powerful!

## Changelog

:cl: vinylspiders
fix: Fixes a bug where your mother would delete your species after calling you a disappointment, rendering you a broken husk of a mob
/:cl: