### PR TITLE
 Fix tesla coil zaps. 

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -116,7 +116,7 @@
 	power = min(surplus(), power) //Take the smaller of the two
 	add_load(power)
 	playsound(src.loc, 'sound/magic/lightningshock.ogg', zap_sound_volume, TRUE, zap_sound_range)
-	tesla_zap(src, 10, power, zap_flags)
+	tesla_zap(src, 10, power, 1e3, zap_flags)
 	zap_buckle_check(power)
 
 /obj/machinery/power/energy_accumulator/grounding_rod

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -199,13 +199,13 @@
 	C.investigate_log("has been dusted by an energy ball.", INVESTIGATE_DEATHS)
 	C.dust()
 
-/proc/tesla_zap(atom/source, zap_range = 3, power, zap_flags = ZAP_DEFAULT_FLAGS, list/shocked_targets = list())
+/proc/tesla_zap(atom/source, zap_range = 3, power, cutoff = 4e5, zap_flags = ZAP_DEFAULT_FLAGS, list/shocked_targets = list())
 	if(QDELETED(source))
 		return
 	if(!(zap_flags & ZAP_ALLOW_DUPLICATES))
 		LAZYSET(shocked_targets, source, TRUE) //I don't want no null refs in my list yeah?
 	. = source.dir
-	if(power < 4e5)
+	if(power < cutoff)
 		return
 
 	/*


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24447
Original PR: https://github.com/tgstation/tgstation/pull/79061
--------------------

## About The Pull Request
Fixes tesla coil zap cutoff being scaled high when it didn't need to. Tesla coil zaps didn't scale with the old power scaling before it got removed, so the tesla coil zaps got nerfed due to the scaling changes of zap effects. This PR does not fix the fact that tesla coil zaps will deal less damage though. An easy clean fix doesn't seem possible, and adding a damage multiplier is cringe.

For fixing tesla coil zap damage, the only reasonable solution seems to be to unscale almost every other zapper (the vast majority of them don't seem to be able to power the grid, so it doesn't matter), and then scaling zap damage scaling back up. I haven't setup my development environment yet, so I'll fix that in another PR.
## Why It's Good For The Game
So the tesla coil doesn't need unreasonably high requirements to zap properly.
## Changelog
:cl: Pickle-Coding
fix: Fixed tesla coil zaps cutting off too early.
/:cl:
