### PR TITLE
[MODULAR]  Improves the UX of synth wounds + fixes RCDs on collapsed superstructures

### DIFF
--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/robotic_blunt_T3.dm
@@ -242,7 +242,8 @@
 	var/has_enough_matter = (treating_rcd.get_matter(user) > ROBOTIC_T3_BLUNT_WOUND_RCD_COST)
 	var/silo_has_enough_materials = (treating_rcd.get_silo_iron() > ROBOTIC_T3_BLUNT_WOUND_RCD_SILO_COST)
 
-	if (!silo_has_enough_materials && has_enough_matter)
+	if (!silo_has_enough_materials && !has_enough_matter) // neither the silo, nor the rcd, has enough
+		user?.balloon_alert(user, "not enough matter!")
 		return TRUE
 
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
@@ -291,7 +292,8 @@
 	set_superstructure_status(TRUE)
 
 	var/use_amount = (silo_has_enough_materials ? ROBOTIC_T3_BLUNT_WOUND_RCD_SILO_COST : ROBOTIC_T3_BLUNT_WOUND_RCD_COST)
-	treating_rcd.useResource(use_amount, user)
+	if (!treating_rcd.useResource(use_amount, user))
+		return TRUE
 
 	if (user)
 		var/misused_text = (misused ? ", though it replaced a bit more than it should've..." : "!")
@@ -383,3 +385,14 @@
 /datum/wound/blunt/robotic/secures_internals/critical/proc/set_superstructure_status(remedied)
 	superstructure_remedied = remedied
 	ready_to_secure_internals = remedied
+
+/datum/wound/blunt/robotic/secures_internals/critical/get_wound_step_info()
+	. = ..()
+
+	if (!superstructure_remedied)
+		. = "The superstructure must be reformed."
+		if (!limb_malleable())
+			. += " The limb must be heated to thermal overload, then manually molded with a firm grasp"
+		else
+			. += " The limb has been sufficiently heated, and can be manually molded with a firm grasp/repeated application of a low-force object"
+		. += " - OR an RCD may be used with little risk."

--- a/modular_skyrat/modules/medical/code/wounds/synth/blunt/secures_internals.dm
+++ b/modular_skyrat/modules/medical/code/wounds/synth/blunt/secures_internals.dm
@@ -160,7 +160,9 @@
 	var/their_or_other = (user == victim ? "[user.p_their()]" : "[victim]'s")
 	var/your_or_other = (user == victim ? "your" : "[victim]'s")
 
-	var/self_message = span_warning("You start prying open [your_or_other] [limb.plaintext_zone] with [crowbarring_item]...")
+	var/limb_can_shock_pre_sleep = (victim.stat != DEAD && limb.biological_state & BIO_WIRED)
+	var/shock_or_not = (limb_can_shock_pre_sleep ? ", risking electrocution" : "")
+	var/self_message = span_warning("You start prying open [your_or_other] [limb.plaintext_zone] with [crowbarring_item][shock_or_not]...")
 
 	user?.visible_message(span_bolddanger("[user] starts prying open [their_or_other] [limb.plaintext_zone] with [crowbarring_item]!"), self_message, ignored_mobs = list(victim))
 
@@ -175,7 +177,7 @@
 	if (!crowbarring_item.use_tool(target = victim, user = user, delay = (7 SECONDS * delay_mult), volume = 50, extra_checks = CALLBACK(src, PROC_REF(still_exists))))
 		return TRUE
 
-	var/limb_can_shock = (victim.stat != DEAD && limb.biological_state & BIO_WIRED)
+	var/limb_can_shock = (victim.stat != DEAD && limb.biological_state & BIO_WIRED) // re-define the previous shock variable because we slept
 	var/stunned = FALSE
 
 	var/message
@@ -386,3 +388,29 @@
 		span_notice("You finish re-soldering [your_or_other] [limb.plaintext_zone]!"))
 	remove_wound()
 	return TRUE
+
+/// Returns a string with our current treatment step for use in health analyzers.
+/datum/wound/blunt/robotic/secures_internals/proc/get_wound_step_info()
+	var/string
+
+	if (ready_to_resolder)
+		string = "Apply a welder/cautery to the limb to finalize repairs."
+	else if (ready_to_secure_internals)
+		string = "Use a screwdriver/wrench to secure the internals of the limb. This step is best performed by a qualified technician. \
+		In absence of one, bone gel or a crowbar may be used."
+
+	return string
+
+/datum/wound/blunt/robotic/secures_internals/get_scanner_description(mob/user)
+	. = ..()
+
+	var/wound_step = get_wound_step_info()
+	if (wound_step)
+		. += "\n\n<b>Current step</b>: [span_notice(wound_step)]"
+
+/datum/wound/blunt/robotic/secures_internals/get_simple_scanner_description(mob/user)
+	. = ..()
+
+	var/wound_step = get_wound_step_info()
+	if (wound_step)
+		. += "\n\n<b>Current step</b>: [span_notice(wound_step)]"


### PR DESCRIPTION
## **Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24416**
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Blunt wounds now display the current step and specific treatment instructions on wound scans. Crowbarring open a T2/3 wound now warns you if it can shock you.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

bugs bad and qol good

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/59709059/5608a72a-39cf-4aeb-97e0-5244f6c87dd4)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: nikothedude
fix: Unlinked RCDs now function on T3 synth blunt wounds
qol: Synthetic blunt wounds now show their current step along with instructions on wound scans
qol: Synthetic blunt wounds now warn you if crowbarring open the limb can shock you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
