### PR TITLE
arrows can be converted

### DIFF
--- a/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
+++ b/modular_skyrat/modules/reagent_forging/code/forge_weapons.dm
@@ -239,22 +239,29 @@
 	. = ..()
 	AddComponent(/datum/component/reagent_weapon)
 
-/obj/item/ammo_casing/arrow/forged
-	desc = "An arrow made of wood, typically fired from a bow. It can be reinforced with sinew."
-	projectile_type = /obj/projectile/bullet/arrow/forged
-
-/obj/item/ammo_casing/arrow/forged/attackby(obj/item/attacking_item, mob/user, params)
+/obj/item/ammo_casing/arrow/attackby(obj/item/attacking_item, mob/user, params)
+	var/spawned_item
 	if(istype(attacking_item, /obj/item/stack/sheet/sinew))
-		var/obj/item/stack/stack_item = attacking_item
-		if(!stack_item.use(1))
-			return
-		new /obj/item/ammo_casing/arrow/ash(get_turf(src))
-		qdel(src)
-		return
-	return ..()
+		spawned_item = /obj/item/ammo_casing/arrow/ash
 
-/obj/projectile/bullet/arrow/forged
-	projectile_type = /obj/item/ammo_casing/arrow/forged
+	if(istype(attacking_item, /obj/item/stack/sheet/bone))
+		spawned_item = /obj/item/ammo_casing/arrow/bone
+
+	if(istype(attacking_item, /obj/item/stack/tile/bronze))
+		spawned_item = /obj/item/ammo_casing/arrow/bronze
+
+	if(!spawned_item)
+		return ..()
+
+	var/obj/item/stack/stack_item = attacking_item
+	if(!stack_item.use(1))
+		return
+
+	var/obj/item/ammo_casing/arrow/converted_arrow = new spawned_item(get_turf(src))
+	transfer_fingerprints_to(converted_arrow)
+	remove_item_from_storage(user)
+	user.put_in_hands(converted_arrow)
+	qdel(src)
 
 #define INCREASE_BLOCK_CHANGE 2
 


### PR DESCRIPTION
## **Original PR: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24449**
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds the ability to transform arrows to different types by attacking them with the conversion item (bronze tile to bronze arrow, bone to bone arrow, and sinew to ash arrow).

I also removed the forged arrow subtype-- after some well needed qol PRs, they became unused and not necessary.

THIS DOES NOT REMOVE THE RECIPES-- there may be cases where you need to be able to craft them so I kept the recipes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Rather than being stuck in the crafting menu, more item interactions like this keeps "immersion."
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>
  
![image](https://github.com/Skyrat-SS13/Skyrat-tg/assets/55967837/6fbbca86-d264-4c03-b70b-3f28f752e92a)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: jjpark-kb
add: you can change arrows into different types by hitting them with the conversion item (bronze tile for bronze, bone for bone, and sinew for ash)
del: removes the forged arrow subtype
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
