### PR TITLE
 Removes progression from midround and latejoin traitor, renames reputation to threat level 

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -60,7 +60,7 @@
 
 /datum/dynamic_ruleset/latejoin/infiltrator
 	name = "Syndicate Infiltrator"
-	antag_datum = /datum/antagonist/traitor
+	antag_datum = /datum/antagonist/traitor/infiltrator
 	antag_flag = ROLE_SYNDICATE_INFILTRATOR
 	antag_flag_override = ROLE_TRAITOR
 	protected_roles = list(

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -226,7 +226,7 @@
 /datum/dynamic_ruleset/midround/from_living/autotraitor
 	name = "Syndicate Sleeper Agent"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
-	antag_datum = /datum/antagonist/traitor
+	antag_datum = /datum/antagonist/traitor/infiltrator/sleeper_agent
 	antag_flag = ROLE_SLEEPER_AGENT
 	antag_flag_override = ROLE_TRAITOR
 	protected_roles = list(
@@ -264,7 +264,7 @@
 	var/mob/M = pick(candidates)
 	assigned += M
 	candidates -= M
-	var/datum/antagonist/traitor/newTraitor = new
+	var/datum/antagonist/traitor/infiltrator/sleeper_agent/newTraitor = new
 	M.mind.add_antag_datum(newTraitor)
 	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a midround traitor.")
 	log_dynamic("[key_name(M)] was selected by the [name] ruleset and has been made into a midround traitor.")

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -18,6 +18,8 @@
 	default_custom_objective = "Perform an overcomplicated heist on valuable Nanotrasen assets."
 	hardcore_random_bonus = TRUE
 	var/give_objectives = TRUE
+	/// Whether to give secondary objectives to the traitor, which aren't necessary but can be completed for a progression and TC boost.
+	var/give_secondary_objectives = TRUE
 	var/should_give_codewords = TRUE
 	///give this traitor an uplink?
 	var/give_uplink = TRUE
@@ -45,6 +47,16 @@
 	///the final objective the traitor has to accomplish, be it escaping, hijacking, or just martyrdom.
 	var/datum/objective/ending_objective
 
+/datum/antagonist/traitor/infiltrator
+	// Used to denote traitors who have joined midround and therefore have no access to secondary objectives.
+	// Progression elements are best left to the roundstart antagonists
+	// There will still be a timelock on uplink items
+	name = "\improper Infiltrator"
+	give_secondary_objectives = FALSE
+
+/datum/antagonist/traitor/infiltrator/sleeper_agent
+	name = "\improper Syndicate Sleeper Agent"
+
 /datum/antagonist/traitor/New(give_objectives = TRUE)
 	. = ..()
 	src.give_objectives = give_objectives
@@ -67,8 +79,9 @@
 		uplink_handler.has_progression = TRUE
 		SStraitor.register_uplink_handler(uplink_handler)
 
-		uplink_handler.has_objectives = TRUE
-		uplink_handler.generate_objectives()
+		if(give_secondary_objectives)
+			uplink_handler.has_objectives = TRUE
+			uplink_handler.generate_objectives()
 
 		uplink_handler.can_replace_objectives = CALLBACK(src, PROC_REF(can_change_objectives))
 		uplink_handler.replace_objectives = CALLBACK(src, PROC_REF(submit_player_objective))

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -52,7 +52,7 @@
 	// Progression elements are best left to the roundstart antagonists
 	// There will still be a timelock on uplink items
 	name = "\improper Infiltrator"
-	give_secondary_objectives = FALSE
+	//give_secondary_objectives = FALSE //FLUFFY FRONTIER REMOVAL - Трейторы всё же должны иметь побочки.
 
 /datum/antagonist/traitor/infiltrator/sleeper_agent
 	name = "\improper Syndicate Sleeper Agent"

--- a/modular_skyrat/modules/Midroundtraitor/code/datum_traitor.dm
+++ b/modular_skyrat/modules/Midroundtraitor/code/datum_traitor.dm
@@ -1,10 +1,10 @@
-/datum/antagonist/traitor/infiltrator
+/datum/antagonist/traitor/lone_infiltrator
 	name = "Lone Infiltrator"
 	var/infil_outfit = /datum/outfit/syndicateinfiltrator
 	preview_outfit = /datum/outfit/lone_infiltrator_preview
 	job_rank = ROLE_LONE_INFILTRATOR
 
-/datum/antagonist/traitor/infiltrator/on_gain()
+/datum/antagonist/traitor/lone_infiltrator/on_gain()
 	var/mob/living/carbon/human/current = owner.current
 	current.equipOutfit(infil_outfit)
 	var/chosen_name = current.dna.species.random_name(current.gender,1,1)

--- a/modular_skyrat/modules/Midroundtraitor/code/event.dm
+++ b/modular_skyrat/modules/Midroundtraitor/code/event.dm
@@ -1,6 +1,6 @@
 /datum/dynamic_ruleset/midround/from_ghosts/lone_infiltrator
 	name = "Lone Infiltrator"
-	antag_datum = /datum/antagonist/traitor/infiltrator
+	antag_datum = /datum/antagonist/traitor/lone_infiltrator
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
 	antag_flag = ROLE_LONE_INFILTRATOR
 	restricted_roles = list(JOB_CYBORG,
@@ -46,7 +46,7 @@
 	player_mind.special_role = "Lone Infiltrator"
 	player_mind.active = TRUE
 	player_mind.transfer_to(operative)
-	player_mind.add_antag_datum(/datum/antagonist/traitor/infiltrator)
+	player_mind.add_antag_datum(/datum/antagonist/traitor/lone_infiltrator)
 
 	message_admins("[ADMIN_LOOKUPFLW(operative)] has been made into lone infiltrator by midround ruleset.")
 	log_game("[key_name(operative)] was spawned as a lone infiltrator by midround ruleset.")

--- a/tgui/packages/tgui/interfaces/TraitorObjectiveDebug.tsx
+++ b/tgui/packages/tgui/interfaces/TraitorObjectiveDebug.tsx
@@ -1,7 +1,7 @@
 import { useBackend, useLocalState } from '../backend';
 import { Box, LabeledList, Stack, Tabs, Tooltip } from '../components';
 import { Window } from '../layouts';
-import { getReputation } from './Uplink/calculateReputationLevel';
+import { getDangerLevel } from './Uplink/calculateDangerLevel';
 
 type Objective = {
   name: string;
@@ -271,7 +271,7 @@ export const TraitorObjectiveDebug = (props, context) => {
             ))}
           </Stack>
           {player_data.map((value) => {
-            const rep = getReputation(value.progression_points);
+            const rep = getDangerLevel(value.progression_points);
             return (
               <Tooltip
                 key={value.player}

--- a/tgui/packages/tgui/interfaces/Uplink/ObjectiveMenu.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/ObjectiveMenu.tsx
@@ -1,7 +1,7 @@
 import { BooleanLike, classes } from 'common/react';
 import { Component } from 'inferno';
 import { Section, Stack, Box, Button, Flex, Tooltip, NoticeBox, Dimmer, Icon } from '../../components';
-import { calculateProgression, getReputation, Rank } from './calculateReputationLevel';
+import { calculateProgression, getDangerLevel, Rank } from './calculateDangerLevel';
 import { ObjectiveState } from './constants';
 
 export type Objective = {
@@ -280,12 +280,12 @@ const ObjectiveFunction = (
   handleAbort?: (objective: Objective) => void,
   grow: boolean = false
 ) => {
-  const reputation = getReputation(objective.progression_minimum);
+  const dangerLevel = getDangerLevel(objective.progression_minimum);
   return (
     <ObjectiveElement
       name={objective.name}
       description={objective.description}
-      reputation={reputation}
+      dangerLevel={dangerLevel}
       telecrystalReward={objective.telecrystal_reward}
       telecrystalPenalty={objective.telecrystal_penalty}
       progressionReward={objective.progression_reward}
@@ -318,7 +318,7 @@ const ObjectiveFunction = (
                   content={value.name}
                   icon={value.icon}
                   tooltip={value.tooltip}
-                  className={reputation.gradient}
+                  className={dangerLevel.gradient}
                   onClick={() => {
                     handleObjectiveAction(objective, value.action);
                   }}
@@ -334,7 +334,7 @@ const ObjectiveFunction = (
 
 type ObjectiveElementProps = {
   name: string;
-  reputation: Rank;
+  dangerLevel: Rank;
   description: string;
   telecrystalReward: number;
   progressionReward: number;
@@ -354,7 +354,7 @@ type ObjectiveElementProps = {
 export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
   const {
     name,
-    reputation,
+    dangerLevel,
     description,
     uiButtons = null,
     telecrystalReward,
@@ -399,7 +399,7 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
         <Box
           className={classes([
             'UplinkObjective__Titlebar',
-            reputation.gradient,
+            dangerLevel.gradient,
           ])}
           width="100%"
           height="100%">
@@ -451,13 +451,13 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
                       'border-right': 'none',
                       'border-bottom': objectiveFinished ? 'none' : undefined,
                     }}
-                    className={reputation.gradient}
+                    className={dangerLevel.gradient}
                     py={0.5}
                     width="100%"
                     textAlign="center">
                     {telecrystalReward} TC,
                     <Box ml={1} as="span">
-                      {calculateProgression(progressionReward)} Reputation
+                      {calculateProgression(progressionReward)} Threat Level
                       {Math.abs(progressionDiff) > 10 && (
                         <Tooltip
                           content={
@@ -476,9 +476,9 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
                                 as="span">
                                 {Math.abs(progressionDiff)}%
                               </Box>
-                              {progressionDiff > 0 ? 'less' : 'more'} reputation
-                              from this objective. This is because your
-                              reputation is{' '}
+                              {progressionDiff > 0 ? 'less' : 'more'} threat
+                              from this objective. This is because your threat
+                              level is{' '}
                               {progressionDiff > 0 ? 'ahead ' : 'behind '}
                               where it normally should be at.
                             </Box>
@@ -504,7 +504,7 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
                 {objectiveFinished ? (
                   <Box
                     inline
-                    className={reputation.gradient}
+                    className={dangerLevel.gradient}
                     style={{
                       'border-radius': '0',
                       'border': '2px solid rgba(0, 0, 0, 0.5)',

--- a/tgui/packages/tgui/interfaces/Uplink/PrimaryObjectiveMenu.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/PrimaryObjectiveMenu.tsx
@@ -59,7 +59,7 @@ export const PrimaryObjectiveMenu = (
                 key={prim_obj.id}
                 name={prim_obj['task_name']}
                 description={prim_obj['task_text']}
-                reputation={{
+                dangerLevel={{
                   minutesLessThan: 0,
                   title: 'none',
                   gradient:

--- a/tgui/packages/tgui/interfaces/Uplink/calculateDangerLevel.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/calculateDangerLevel.tsx
@@ -20,60 +20,60 @@ export type Rank = {
 export const ranks: Rank[] = [
   {
     minutesLessThan: 5,
-    title: 'Obscure',
+    title: 'None',
     gradient: badGradient,
   },
   {
     minutesLessThan: 10,
-    title: 'Insignificant',
+    title: 'Miniscule',
     gradient: normalGradient,
   },
   {
     minutesLessThan: 20,
-    title: 'Noteworthy',
+    title: 'Insignificant',
     gradient: normalGradient,
   },
   {
     minutesLessThan: 30,
-    title: 'Reputable',
+    title: 'Low',
     gradient: goodGradient,
   },
   {
     minutesLessThan: 50,
-    title: 'Well-known',
+    title: 'Standard',
     gradient: goodGradient,
   },
   {
     minutesLessThan: 70,
-    title: 'Significant',
+    title: 'Moderate',
     gradient: veryGoodGradient,
   },
   {
     minutesLessThan: 90,
-    title: 'Famous',
+    title: 'Significant',
     gradient: veryGoodGradient,
   },
   {
     minutesLessThan: 110,
-    title: 'Glorious',
+    title: 'High',
     gradient: ultraGoodGradient,
   },
   {
     minutesLessThan: 140,
-    title: 'Fabled',
+    title: 'Extreme',
     gradient: ultraGoodGradient,
   },
   {
     minutesLessThan: -1,
-    title: 'Legendary',
+    title: 'Pinnacle',
     gradient: bestGradient,
   },
 ];
 
-export const reputationDefault = 50 * 600;
+export const dangerDefault = 50 * 600;
 
 let lastMinutesThan = -1;
-export const reputationLevelsTooltip = (
+export const dangerLevelsTooltip = (
   <Box preserveWhitespace>
     <Flex direction="column" mt={1}>
       {ranks.map((value) => {
@@ -104,7 +104,7 @@ export const reputationLevelsTooltip = (
   </Box>
 );
 
-export const getReputation = (progression_points: number) => {
+export const getDangerLevel = (progression_points: number) => {
   const minutes = progression_points / 600;
 
   for (let index = 0; index < ranks.length; index++) {
@@ -117,31 +117,31 @@ export const getReputation = (progression_points: number) => {
   return ranks[ranks.length - 1];
 };
 
-export const calculateReputationLevel = (
+export const calculateDangerLevel = (
   progression_points: number,
   textOnly: boolean
 ) => {
   const minutes = progression_points / 600;
   const displayedProgression = calculateProgression(progression_points);
-  const reputation = getReputation(progression_points);
+  const dangerLevel = getDangerLevel(progression_points);
   if (textOnly) {
     return (
       <Box as="span">
-        {reputation.title} ({displayedProgression})
+        {dangerLevel.title} ({displayedProgression})
       </Box>
     );
   }
   return (
     <Box
       color="white"
-      className={reputation.gradient}
+      className={dangerLevel.gradient}
       style={{
         'border-radius': '5px',
         'display': 'inline-block',
       }}
       px={0.8}
       py={0.6}>
-      {reputation.title} ({displayedProgression})
+      {dangerLevel.title} ({displayedProgression})
     </Box>
   );
 };

--- a/tgui/packages/tgui/interfaces/Uplink/index.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/index.tsx
@@ -8,7 +8,7 @@ import { BooleanLike } from 'common/react';
 import { Box, Tabs, Button, Stack, Section, Tooltip, Dimmer } from '../../components';
 import { PrimaryObjectiveMenu } from './PrimaryObjectiveMenu';
 import { Objective, ObjectiveMenu } from './ObjectiveMenu';
-import { calculateProgression, calculateReputationLevel, reputationDefault, reputationLevelsTooltip } from './calculateReputationLevel';
+import { calculateProgression, calculateDangerLevel, dangerDefault, dangerLevelsTooltip } from './calculateDangerLevel';
 
 type UplinkItem = {
   id: string;
@@ -227,7 +227,7 @@ export class Uplink extends Component<{}, UplinkState> {
               <>
                 ,&nbsp;
                 <Box as="span">
-                  {calculateReputationLevel(item.progression_minimum, true)}
+                  {calculateDangerLevel(item.progression_minimum, true)}
                 </Box>
               </>
             ) : (
@@ -280,12 +280,15 @@ export class Uplink extends Component<{}, UplinkState> {
                           (!!has_progression && (
                             <Box>
                               <Box>
-                                Your current level of reputation.&nbsp;
-                                Reputation determines what quality of objective
-                                you get and what items you can purchase.&nbsp;
+                                <Box>Your current level of threat.</Box> Threat
+                                determines
+                                {has_objectives
+                                  ? ' the severity of secondary objectives you get and '
+                                  : ' '}
+                                what items you can purchase.&nbsp;
                                 <Box mt={0.5}>
                                   {/* A minute in deciseconds */}
-                                  Reputation passively increases by{' '}
+                                  Threat passively increases by{' '}
                                   <Box color="green" as="span">
                                     {calculateProgression(
                                       current_progression_scaling
@@ -295,10 +298,10 @@ export class Uplink extends Component<{}, UplinkState> {
                                 </Box>
                                 {Math.abs(progressionPercentage) > 0 && (
                                   <Box mt={0.5}>
-                                    Because your reputation is{' '}
+                                    Because your threat level is
                                     {progressionPercentage < 0
-                                      ? 'ahead '
-                                      : 'behind '}
+                                      ? ' ahead '
+                                      : ' behind '}
                                     of where it should be, you are getting
                                     <Box
                                       as="span"
@@ -314,20 +317,20 @@ export class Uplink extends Component<{}, UplinkState> {
                                     {progressionPercentage < 0
                                       ? 'less'
                                       : 'more'}{' '}
-                                    reputation every minute
+                                    threat every minute
                                   </Box>
                                 )}
-                                {reputationLevelsTooltip}
+                                {dangerLevelsTooltip}
                               </Box>
                             </Box>
                           )) ||
-                          'Your current level of reputation. You are a respected elite and do not need to improve your reputation.'
+                          "Your current threat level. You are a killing machine and don't need to improve your threat level."
                         }>
                         {/* If we have no progression,
                       just give them a generic title */}
                         {has_progression
-                          ? calculateReputationLevel(progression_points, false)
-                          : calculateReputationLevel(reputationDefault, false)}
+                          ? calculateDangerLevel(progression_points, false)
+                          : calculateDangerLevel(dangerDefault, false)}
                       </Tooltip>
                     </Box>
                     <Box color="good" bold fontSize={1.2} textAlign="right">


### PR DESCRIPTION
Mirrored on Skyrat: https://github.com/Skyrat-SS13/Skyrat-tg/pull/24374
Original PR: https://github.com/tgstation/tgstation/pull/79020
--------------------

## About The Pull Request
Reputation has been renamed to 'Threat Level' to more accurately represent what it means.
Midround and latejoin traitors no longer have access to secondary objectives, the ones which give TC and objectives.

## Why It's Good For The Game
Midround antagonists, like traitor, shouldn't really have the progression system that is meant for roundstart. Final objectives in particular are only suited for traitors who have worked towards it from the start.
Reputation wasn't really a good name for the player-facing progression system of traitors as you'd passively gain progression which didn't make since if it was supposed to be your reputation.

## Changelog
:cl: Watermelon914
balance: Removed secondary objectives from midround and latejoin traitors.
grammar: Renamed reputation to threat level.
/:cl:
