### PR TITLE
Исправление бага c Активистами

### DIFF
--- a/tff_modular/modules/custom_revolution/code/rev_head_role.dm
+++ b/tff_modular/modules/custom_revolution/code/rev_head_role.dm
@@ -100,7 +100,8 @@
 
 /datum/action/cooldown/create_brochure
 	name = "Create brochure"
-	cooldown_time = 30 // 30 ticks = 3 sec
+	cooldown_time = 3 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
 	var/datum/weakref/owner_antag_datum_ref = new()
 	button_icon = 'tff_modular/modules/custom_revolution/icons/items.dmi'
 	button_icon_state = "brochure"

--- a/tff_modular/modules/custom_revolution/code/rev_team_role.dm
+++ b/tff_modular/modules/custom_revolution/code/rev_team_role.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_INIT(custom_rev_teams, list())
 	var/mob/living/M = mob_override || owner.current
 	add_team_hud(M, rev_team)
 
-/// Удаляем роль при введении майндшилда.
+/// Удаляем роль при введении майндшилда, если ignore_mindshield == FALSE.
 /datum/antagonist/custom_rev/on_mindshield(mob/implanter)
 	var/mob/antag_mob = owner.current
 	if(rev_team.ignore_mindshield)
@@ -70,13 +70,13 @@ GLOBAL_LIST_INIT(custom_rev_teams, list())
 /datum/team/custom_rev_team
 	name = "\improper Activists"
 	member_name = "\improper activist"
-	// Кастомизация брошюры.
+	// Кастомизация брошюры
 	var/brochure_name = "some strange brochure"
 	var/brochure_desc = "Strange brochure made of durable material. There is something written in and on it."
 	var/brochure_icon_state = "brochure"
 	var/icon/brochure_icon = 'tff_modular/modules/custom_revolution/icons/items.dmi'
 	var/brochure_message = "Do you want to be a part of our union?"
-	// Кастомизация фичей...
+	// Кастомизация фичей
 	var/ignore_mindshield = FALSE
 	var/ignore_deconvert_machine = FALSE
 	


### PR DESCRIPTION
## О Pull Request

Лидер активистов больше не сможет спавнить брошюры будучи без сознания или мёртвым.

## Как это может улучшит/повлиять на игровой процесс/ролевую игру

Меньше багов = хорошо

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

![dreamseeker_koDykPipRp](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/165e257f-8deb-4536-aba3-2f7d93609059)
  
![dreamseeker_imo856j9Nd](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/76b47b4d-f624-4a47-95e3-762cbcf47870)

![dreamseeker_afeRIhGurV](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/b93eba9e-ba1a-4a3e-a635-bb57351030b5)

</details>

## Changelog

:cl:
fix: Leader activist no longer able to spawn brochures while being unconscious or dead.
/:cl:
