### PR TITLE
Перемещение стартового оружия БЩ в маяк доставки с выбором снаряжения.

### DIFF
--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -43,7 +43,7 @@
 	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_OPEN_SLOTS
 
 /datum/outfit/job/blueshield
-	// FLUFFY FRONTIER COMMENT: Любое добавленное крысами тут оружие - вырезайте и переносите в /obj/item/choice_beacon/blueshield!
+	// FLUFFY FRONTIER COMMENT - BLUESHIELD-REARM: Любое добавленное крысами тут оружие переносим в наш модуль, в /obj/item/choice_beacon/blueshield!
 	name = "Blueshield"
 	jobtype = /datum/job/blueshield
 	uniform = /obj/item/clothing/under/rank/blueshield

--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -43,6 +43,7 @@
 	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_OPEN_SLOTS
 
 /datum/outfit/job/blueshield
+	// FLUFFY FRONTIER COMMENT: Любое добавленное крысами тут оружие - вырезайте и переносите в /obj/item/choice_beacon/blueshield!
 	name = "Blueshield"
 	jobtype = /datum/job/blueshield
 	uniform = /obj/item/clothing/under/rank/blueshield
@@ -52,9 +53,6 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	ears = /obj/item/radio/headset/headset_bs/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
-	// FLUFFY FRONTIER EDIT: ADDITION
-	suit_store = /obj/item/storage/belt/holster/energy/blueshield
-	// FLUFFY FRONTIER EDIT END.
 	implants = list(/obj/item/implant/mindshield)
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield

--- a/modular_skyrat/modules/blueshield/code/closet.dm
+++ b/modular_skyrat/modules/blueshield/code/closet.dm
@@ -23,8 +23,12 @@
 /obj/structure/closet/secure_closet/blueshield/New()
 	..()
 	// FLUFFY FRONTIER EDIT: ADDITION
-	// Sometimes blueshields don't want to have tackler gloves,
-	// So i gave him same gloves, but without tackler ability.
+	// ВАЖНО!! ДАБЫ НЕ ПЕРЕНАСЫЩАТЬ БЩ ОРУЖИЕМ, ЛЮБЫЕ НОВЫЕ ПУШКИ СТОИТ ПЕРЕНОСИТЬ СЮДА:
+	// ПУТЬ ОБЪЕКТА: /obj/item/choice_beacon/blueshield
+	// ПУТЬ ДО ФАЙЛА: tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
+
+
+	// Выдал БЩ дополнительные перчатки, аналогичные их стандартным, просто без эффекта рывка.
 	new /obj/item/clothing/gloves/combat(src)
 	// FLUFFY FRONTIER EDIT END.
 	new /obj/item/storage/secure/briefcase(src)
@@ -34,6 +38,6 @@
 	new /obj/item/restraints/handcuffs(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/storage/medkit/tactical/blueshield(src)
-	new /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano(src)
+	// FF EDIT: DELETION. DELETED LINE: new /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano(src)
 	new /obj/item/storage/bag/garment/blueshield(src)
 	new /obj/item/mod/control/pre_equipped/blueshield(src)

--- a/modular_skyrat/modules/blueshield/code/closet.dm
+++ b/modular_skyrat/modules/blueshield/code/closet.dm
@@ -22,15 +22,11 @@
 
 /obj/structure/closet/secure_closet/blueshield/New()
 	..()
-	// FLUFFY FRONTIER EDIT: ADDITION
-	// ВАЖНО!! ДАБЫ НЕ ПЕРЕНАСЫЩАТЬ БЩ ОРУЖИЕМ, ЛЮБЫЕ НОВЫЕ ПУШКИ СТОИТ ПЕРЕНОСИТЬ СЮДА:
-	// ПУТЬ ОБЪЕКТА: /obj/item/choice_beacon/blueshield
-	// ПУТЬ ДО ФАЙЛА: tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
-
-
+	// FLUFFY FRONTIER EDIT: ADDITION BEGIN - BLUESHIELD-REARM
+	// ВАЖНО!! ДАБЫ НЕ ПЕРЕНАСЫЩАТЬ БЩ ОРУЖИЕМ, ЛЮБЫЕ НОВЫЕ ПУШКИ ПЕРЕНОСИМ В МОДУЛЬ В /obj/item/choice_beacon/blueshield/
 	// Выдал БЩ дополнительные перчатки, аналогичные их стандартным, просто без эффекта рывка.
 	new /obj/item/clothing/gloves/combat(src)
-	// FLUFFY FRONTIER EDIT END.
+	// FLUFFY FRONTIER EDIT END - BLUESHIELD-REARM.
 	new /obj/item/storage/secure/briefcase(src)
 	new /obj/item/storage/belt/security/full(src)
 	new /obj/item/grenade/flashbang(src)
@@ -38,6 +34,6 @@
 	new /obj/item/restraints/handcuffs(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/storage/medkit/tactical/blueshield(src)
-	// FF EDIT: DELETION. DELETED LINE: new /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano(src)
+	// new /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano(src) FF EDIT: DELETION - BLUESHIELD-REARM
 	new /obj/item/storage/bag/garment/blueshield(src)
 	new /obj/item/mod/control/pre_equipped/blueshield(src)

--- a/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
+++ b/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
@@ -1,0 +1,32 @@
+/obj/item/choice_beacon/blueshield
+	name = "bodyguard weapon delivery beacon"
+	desc = "Weapon delivery beacon designed specially for picky Blueshield Agents."
+	icon_state = "gangtool-red"
+	w_class = WEIGHT_CLASS_TINY
+
+/obj/item/choice_beacon/blueshield/generate_display_names()
+	var/static/list/blueshield_weapons
+	if(!blueshield_weapons)
+		blueshield_weapons = list()
+		var/list/possible_weapons = list(
+			// Пример для своего значения:
+			// путь_оружия = путь_набор_с_оружием,
+			// При такой записи в списке будет отображаться название оружия,
+			// а доставкой прилетит набор с оружием.
+			/obj/item/gun/energy/blueshield = /obj/item/storage/belt/holster/energy/blueshield,
+			/obj/item/gun/ballistic/automatic/sol_smg = /obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/sindano,
+		)
+		for(var/obj/item/weapon as anything in possible_weapons)
+			blueshield_weapons[initial(weapon.name)] = possible_weapons[weapon]
+
+	return blueshield_weapons
+
+// ОЧЕНЬ костыльный, но всё же модульный способ впихнуть это в сумку
+
+/datum/outfit/job/blueshield/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	if(!backpack_contents) 
+		backpack_contents = list()
+	if(!(/obj/item/choice_beacon/blueshield in backpack_contents))
+		backpack_contents += /obj/item/choice_beacon/blueshield
+	. = ..()
+	

--- a/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
+++ b/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
@@ -22,11 +22,9 @@
 	return blueshield_weapons
 
 // ОЧЕНЬ костыльный, но всё же модульный способ впихнуть это в сумку
-
 /datum/outfit/job/blueshield/pre_equip(mob/living/carbon/human/H, visualsOnly)
-	if(!backpack_contents) 
+	if(!backpack_contents)
 		backpack_contents = list()
 	if(!(/obj/item/choice_beacon/blueshield in backpack_contents))
 		backpack_contents += /obj/item/choice_beacon/blueshield
 	. = ..()
-	

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7859,6 +7859,7 @@
 #include "tff_modular\modules\blueshield-rearm\code\holster.dm"
 #include "tff_modular\modules\blueshield-rearm\code\projectiles.dm"
 #include "tff_modular\modules\blueshield-rearm\code\revolver.dm"
+#include "tff_modular\modules\blueshield-rearm\code\weapon_beacon.dm"
 #include "tff_modular\modules\clothing\suit\suit.dm"
 #include "tff_modular\modules\cqd_holsters\code\holster.dm"
 #include "tff_modular\modules\cqd_holsters\code\holster_injections.dm"


### PR DESCRIPTION
## О Pull Request

Переносит оружие БЩ в маяк для доставки, который позволяет БЩ выбрать оружие с которым он хочет быть.

Также код из этого ПРа может послужить основой для кастомных наборов снаряжения и для других ролей.

## Как это может улучшит/повлиять на игровой процесс/ролевую игру

Сейчас у БЩ от крыс есть "подарок", а именно второе, лишнее оружие, которое спавнится у него в ящике. Просто так вырезать его - я счёл лишним (а также Крысы скоро вместо СМГ могут подарить ему эксклюзивную стреляблу), из-за чего я просто решил выдать Щиту девайс для доставки снаряжения, в котором он cможет выбрать желаемый ствол, так как не всем хочется играть с бластером и наоборот.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>
  
![dreamseeker_KHFQCJikL8](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/789722ec-f09e-4fc1-8141-a5f8d91b7fa0)

![dreamseeker_AvGrCoH5P5](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/2de2da18-84d0-43db-8489-1eae3fcaca85)

![dreamseeker_jy7qyHwWQU](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/10ac0163-f11c-48ee-90ec-302476383ba0)


</details>

## Changelog

:cl:
qol: Blueshield's weaponry now can be picked by the player via delivery beacon.
/:cl:
