### PR TITLE
Фиксим чейнджлоги

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -21,4 +21,4 @@ jobs:
         script: |
           const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
           await processAutoChangelog({ github, context })
-        github-token: ${{ secrets.NOVABOT_TOKEN || secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.SKYRATBOT_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
NOVABOT_TOKEN -> SKYRATBOT_TOKEN

потому что к старому имени был привязан наш ключ)