### PR TITLE
Default rev deconvertion feature

### DIFF
--- a/tff_modular/modules/custom_revolution/code/rev_deconvert_machine.dm
+++ b/tff_modular/modules/custom_revolution/code/rev_deconvert_machine.dm
@@ -171,6 +171,12 @@
 		occupant_mind.current.log_message("has been deconverted from the [antag.rev_team.name] by deconvert machinery!", LOG_GAME, color="red")
 		success = TRUE
 
+	// Также деконвертим дефолтную реву, дабы была альтернатива сомнительному забиванию головы дубинкой
+	var/datum/antagonist/rev/d_rev = occupant_mind.has_antag_datum(/datum/antagonist/rev)
+	if(d_rev)
+		d_rev.remove_revolutionary("deconvert machinery")
+		success = TRUE
+
 	var/obj/item/radio/sec_radio = new (src)
 	sec_radio.set_listening(FALSE)
 	sec_radio.set_frequency(FREQ_SECURITY)


### PR DESCRIPTION
## О Pull Request

Этот ПР добавит деконверт дефолтной ревы через ActiviZero2000

## Как это может улучшит/повлиять на игровой процесс/ролевую игру

Увидел как в раунде спавнят дефолтную реву и ужаснулся тому, что единственная альтернатива майндшилду - это забивание головы ревера.

Я думаю, что нам стоит иметь альтернативный и более гуманный способ деконвертить обычную реву.

## Changelog

:cl:
add: Added new, more humane way to deconvert default revs via ActiviZero2000.
/:cl:
