### PR TITLE
Разрешение на оружие у КМа

### DIFF
--- a/tff_modular/master_files/code/modules/job/job_trim.dm
+++ b/tff_modular/master_files/code/modules/job/job_trim.dm
@@ -1,0 +1,6 @@
+// Файл для модификации трима и доступа у профок.
+
+/datum/id_trim/job/quartermaster/New()
+	. = ..()
+	
+	minimal_access |= ACCESS_WEAPONS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8175,6 +8175,7 @@
 #include "tff_modular\master_files\code\datum\components\riding_mob.dm"
 #include "tff_modular\master_files\code\datum\components\weak_body.dm"
 #include "tff_modular\master_files\code\modules\job\job_blacklist.dm"
+#include "tff_modular\master_files\code\modules\job\job_trim.dm"
 #include "tff_modular\master_files\code\modules\mob\living\carbon\human\_human.dm"
 #include "tff_modular\master_files\code\modules\mob\living\carbon\human\human_buckle.dm"
 #include "tff_modular\master_files\code\modules\mod\_module.dm"


### PR DESCRIPTION
## О Pull Request

Данный ПР добавит разрешение на оружие КМу, так как оно есть буквально у любой другой главы, в том числе СМО и СЕ.

## Как это может улучшит/повлиять на игровой процесс/ролевую игру

Крысы (ныне Новы) выдали всем главам разрешение на оружие, но при этом забрав его у КМа. Причина почему КМ не получил лицензию на оружие - проста, карго по задумке нашего апстрима представляет независимую фракцию "ФТУ", у которой свои СОПы, регуляции и правила, не связанные с НТ, по этому ему не положена НТшная лицензия ведь разрешение на оружие у него есть в пределах территории ФТУ, которой является карго.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>
  
![dreamseeker_wvVtIa670l](https://github.com/Fluffy-Frontier/FluffySTG/assets/121913313/5abf25a2-abfc-4db1-a28d-44201234523d)

</details>

## Changelog

:cl:
add: Weapon permit for QM
/:cl:
