### PR TITLE
FEAT: Syndicate anti-cringe rewrite

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -54,7 +54,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(
 		nanotrasen = list(fax_name = "NT HR Department", fax_id = "central_command", color = "teal", emag_needed = FALSE),
-		syndicate = list(fax_name = "Sabotage Department", fax_id = "syndicate", color = "red", emag_needed = TRUE),
+		syndicate = list(fax_name = "Syndicate Sectorial Command", fax_id = "syndicate", color = "red", emag_needed = TRUE),
 	)
 
 /obj/machinery/fax/auto_name

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -1,4 +1,5 @@
 GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department", "NT Complaint Department", "NT Customer Relations", "Nanotrasen Tech Support", "NT Internal Affairs Dept"))
+GLOBAL_VAR_INIT(synd_fax_department, "Syndicate Sectorial Command")
 
 /obj/machinery/fax
 	name = "Fax Machine"
@@ -54,7 +55,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(
 		nanotrasen = list(fax_name = "NT HR Department", fax_id = "central_command", color = "teal", emag_needed = FALSE),
-		syndicate = list(fax_name = "Syndicate Sectorial Command", fax_id = "syndicate", color = "red", emag_needed = TRUE),
+		syndicate = list(fax_name = "Sabotage Department", fax_id = "syndicate", color = "red", emag_needed = TRUE),
 	)
 
 /obj/machinery/fax/auto_name
@@ -75,6 +76,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	set_wires(new /datum/wires/fax(src))
 	register_context()
 	special_networks["nanotrasen"]["fax_name"] = GLOB.nt_fax_department
+	special_networks["syndicate"]["fax_name"] = GLOB.synd_fax_department
 
 /obj/machinery/fax/Destroy()
 	QDEL_NULL(loaded_item_ref)

--- a/modular_nova/modules/mapping/code/mob_spawns.dm
+++ b/modular_nova/modules/mapping/code/mob_spawns.dm
@@ -44,7 +44,7 @@
 	name = "DS2 personnel"
 	use_outfit_name = TRUE
 	prompt_name = "DS2 personnel"
-	you_are_text = "You are a syndicate operative, employed in a top secret research facility developing biological weapons."
+	you_are_text = "You are a Syndicate operative, employed in a top secret research facility developing biological weapons."
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. Continue operating as best you can, and try to keep a low profile."
 	quirks_enabled = TRUE
 	random_appearance = FALSE
@@ -54,7 +54,7 @@
 /obj/effect/mob_spawn/ghost_role/human/ds2/prisoner
 	name = "Syndicate Prisoner"
 	prompt_name = "a Syndicate prisoner"
-	you_are_text = "You are a syndicate prisoner aboard an unknown ship."
+	you_are_text = "You are a Syndicate prisoner aboard an unknown ship."
 	flavour_text = "Unaware of where you are, all you know is you are a prisoner. The plastitanium should clue you into who your captors are... as for why you're here? That's for you to know, and for us to find out."
 	important_text = "You are still subject to standard prisoner policy and must Adminhelp before antagonizing DS2."
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -68,8 +68,8 @@
 	prompt_name = "a Syndicate operative"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
-	you_are_text = "You are an operative of the Sothran Syndicate terrorist cell, employed onboard the Deep Space 2 FOB for reasons that are yours."
-	flavour_text = "The Sothran Syndicate has found it fit to send a forward operating base to Sector 13 to monitor NT's operations. Your orders are maintaining the ship's integrity and keeping a low profile as well as possible."
+	you_are_text = "You are a Syndicate operative, employed onboard the Deep Space 2 FOB for reasons that are yours."
+	flavour_text = "The Syndicate has found it fit to send a forward operating base to Sector 13 to monitor NT's operations. Your orders are maintaining the ship's integrity and keeping a low profile as well as possible."
 	important_text = "You are not an antagonist. Adminhelp before antagonizing station crew."
 	outfit = /datum/outfit/ds2/syndicate
 	computer_area = /area/ruin/space/has_grav/nova/des_two/halls
@@ -81,8 +81,8 @@
 	prompt_name = "a Syndicate leader"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
-	you_are_text = "You are a command operative of the Sothran Syndicate terrorist cell, employed onboard the Deep Space 2 FOB to guide it forward in its goals."
-	flavour_text = "The Sothran Syndicate has found it fit to send you to help command the forward operating base in Sector 13. Your orders are commanding the crew of DS-2 while keeping a low profile as well as possible."
+	you_are_text = "You are a Syndicate command operative, employed onboard the Deep Space 2 FOB to guide it forward in its goals."
+	flavour_text = "The Syndicate has found it fit to send you to help command the forward operating base in Sector 13. Your orders are commanding the crew of DS-2 while keeping a low profile as well as possible."
 	important_text = "Keep yourself to the same standards as Command Policy. You are not an antagonist and must Adminhelp before antagonizing station crew."
 	outfit = /datum/outfit/ds2/syndicate_command
 	computer_area = /area/ruin/space/has_grav/nova/des_two/halls


### PR DESCRIPTION
## О Pull Request

ПР удаляет немного клюквы, связанной с именованием подразделений у Синдиката. Ганс, наше подразделение называется "террористическая ячейка". Ганс, мы что, злодеи?
- Удаляет упоминания "terrorist cell" из интро-описания у оперативников ДС-2;
- Меняет название факса ЦК Синдиката на "Syndicate Sectorial Command".
## Как это может улучшит/повлиять на игровой процесс/ролевую игру

Уменьшает объем клюквы на квадратный метр в отношении Синдиката. Хотя этот отыгрыш никогда особо не регламентировался, ибо лора нет^TM, достаточно сложно воспринимать себя не карикатурным злом при таких описаниях вашей деятельности.
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>
  
![image](https://github.com/Fluffy-Frontier/FluffySTG/assets/52104104/f95bcb4a-8899-4775-81fa-6157db4d62bc)
![image](https://github.com/Fluffy-Frontier/FluffySTG/assets/52104104/bfa1dc73-52cd-4c11-89c3-fda11e58b563)

</details>

## Changelog
:cl: UEDHighCommand
add: Edited the intro text for DS-2 operatives, removing the cringe-y mention of "terrorist cells"
add: Renamed the Syndicate CentCom fax to "Syndicate Sectorial Command"
/:cl:
