### PR TITLE
Спавн руды вновь более независим от положения относительно рудных вентов.

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -408,7 +408,7 @@
 	baseturfs = /turf/open/misc/asteroid/basalt/lava_land_surface
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	defer_change = TRUE
-	proximity_based = TRUE // Nova Edit: Original TRUE //FF editr - reverted it back
+	proximity_based = FALSE // Nova Edit: Original TRUE
 	mineralChance = 7 // Nova Edit: Original 5 (13)
 
 /turf/closed/mineral/random/volcanic/mineral_chances()
@@ -436,7 +436,7 @@
 	baseturfs = /turf/open/misc/asteroid/snow/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 	weak_turf = TRUE
-	proximity_based = TRUE // Nova Edit: Originally TRUE //FF editr - reverted it back
+	proximity_based = FALSE // Nova Edit: Originally TRUE
 	mineralChance = 8 // Nova Edit: Originally Not defined - lowers from 13
 
 /turf/closed/mineral/random/snow/Change_Ore(ore_type, random = 0)


### PR DESCRIPTION

## О Pull Request
Отключаем зависимость шанса на руду и её количества в жиле от расстояния до рудного вента. У нас есть пинпоинтеры, больше жопная боль с поисками жил по концентрации руды не нужна.
## Как это может улучшит/повлиять на игровой процесс/ролевую игру
Приятнее играть за шахтёра. Особенно на айсбоксе.
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>
  
</details>

## Changelog
:cl:
balance: ore spawns (inside turfs) no longer dependent on proximity of ore vents
/:cl:
