### PR TITLE
tweak capturing time & credit siphoning

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -37,7 +37,7 @@
 #define RESPONSE_MAX_TIME 2 MINUTES
 
 /// How long till a spessman should come back after being captured and sent to the holding facility (which some antags use)
-#define COME_BACK_FROM_CAPTURE_TIME 6 MINUTES
+#define COME_BACK_FROM_CAPTURE_TIME 60 MINUTES // FF edit: 6 -> 60
 
 //ERT Types
 #define ERT_BLUE "Blue"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -37,7 +37,7 @@
 #define RESPONSE_MAX_TIME 2 MINUTES
 
 /// How long till a spessman should come back after being captured and sent to the holding facility (which some antags use)
-#define COME_BACK_FROM_CAPTURE_TIME 60 MINUTES // FF edit: 6 -> 60
+#define COME_BACK_FROM_CAPTURE_TIME 30 MINUTES // FF edit: 6 -> 30
 
 //ERT Types
 #define ERT_BLUE "Blue"

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -67,7 +67,7 @@
 		say("Insufficient power. Halting siphon.")
 		end_siphon()
 		return
-	var/siphon_am = 100 * seconds_per_tick
+	var/siphon_am = 1000 * seconds_per_tick // FF edit: 100 -> 1000
 	if(!synced_bank_account.has_money(siphon_am))
 		say("[synced_bank_account.account_holder] depleted. Halting siphon.")
 		end_siphon()

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -11,7 +11,7 @@
 	/// The amount of money stored in the machine
 	var/credits_stored = 0
 	/// The amount of money removed per tick
-	var/siphon_per_tick = 5
+	var/siphon_per_tick = 200 // FF edit: 5 -> 200
 
 /obj/machinery/shuttle_scrambler/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## О Pull Request

Увеличивает таймер до автоматического возвращения на станцию в случае похищения тритором/контрактором/пиратом с 6 минут до 30. Также банковская машина откачивает по 1000 кредитов, вместо 100. Пиратский сифон качает по 200 кредитов, вместо 5.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Теперь после похищения актива (офицера) пиратом/тритором/контрактором он не вернется на станцию через 5 минут и не продолжит мочить обидчиков как будто ничего не произошло. У игроков все еще есть возможность выкупить похищенные активы через терминал черного рынка. Чтобы была возможность оперативно выкупать похищенных, увеличено количество откачиваемых денег через банк-машину. Также теперь есть возможность пиратить от дефа, качая деньги по 200 кредитов (раньше 5) и отбивая волны сбух.

## Доказательства тестирования

Там только конфиг потвикался

## Changelog

:cl:
balance: capture timing increased from 6 -> 30 minutes
balance: vault bank machine is now siphoning 100 -> 1000 credits
balance: pirate data siphon is now siphoning 5 -> 200 credits 
/:cl:
