### PR TITLE
Блок снарядов еретическим серпом

### DIFF
--- a/tff_modular/master_files/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/tff_modular/master_files/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -1,0 +1,16 @@
+// Даёт серпу еретика возможность блокировать пули и лазеры с шансом 30%.
+// Не-еретики имеют шанс 50% быть порезанными клинком и застаненными на 5 секунд(Стан такой же как при попытке ударить клинком)
+/obj/item/melee/sickly_blade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
+	if(!IS_HERETIC_OR_MONSTER(owner))
+		if(prob(50) && attack_type == PROJECTILE_ATTACK)
+			to_chat(owner, span_danger("You feel a pulse of alien intellect lash out at your mind! It pushes you to cut yourself!"))
+			owner.AdjustParalyzed(5 SECONDS)
+			owner.take_bodypart_damage(20,25,check_armor = FALSE)
+			var/turf/T = get_turf(owner)
+			T.visible_message(span_warning("Unknown force pushes [owner] to cut themself by the blade!"))
+			final_block_chance = 0
+			return FALSE
+	else
+		if(attack_type == PROJECTILE_ATTACK)
+			final_block_chance = 30
+			return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8436,6 +8436,7 @@
 #include "modular_nova\modules\xenos_nova_redo\code\xeno_types\warrior.dm"
 #include "tff_modular\master_files\code\_HELPERS\global_lists.dm"
 #include "tff_modular\master_files\code\datum\quirks\neutral_quirks\burr.dm"
+#include "tff_modular\master_files\code\modules\antagonists\heretic\items\heretic_blades.dm"
 #include "tff_modular\master_files\code\modules\job\job_blacklist.dm"
 #include "tff_modular\master_files\code\modules\job\job_trim.dm"
 #include "tff_modular\master_files\code\modules\reagents\recipe\coagulant_recipe.dm"


### PR DESCRIPTION

## О Pull Request

Еретический нож с вероятностью 30% блокирует снаряды. Не-еретики при попытке блокировать снаряд с вероятностью 50% либо просто пропустят пулю, либо они упадут в стан на 5 секунд и получат 20-25 урона.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Дать еретику хоть какую-то защиту от хусонгов и хоши. Новы у нас СБ-супремаси, поэтому им этот бафф не понравился. На ТГ он естественно не надо.
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>
  

https://github.com/Fluffy-Frontier/FluffySTG/assets/93310496/7a67e935-e85c-4c75-820e-742e954f9c83


</details>

## Changelog
:cl:
add: Added 30% block chance for heretic's blade
/:cl:
