### PR TITLE
Даешь Caligram Armored Tan Parka народу!

### DIFF
--- a/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
+++ b/modular_nova/modules/loadouts/loadout_items/donator/personal/donator_personal.dm
@@ -174,7 +174,26 @@
 /datum/loadout_item/suit/caligram_parka_vest_tan
 	name = "Caligram Armored Tan Parka"
 	item_path = /obj/item/clothing/suit/armor/vest/caligram_parka_vest
-	restricted_roles = list(JOB_BLUESHIELD, JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_CORRECTIONS_OFFICER)
+	// THE FLUFFY FRONTIER EDIT BEGIN
+	// ORIGINAL LINE: restricted_roles = list(JOB_BLUESHIELD, JOB_HEAD_OF_SECURITY, JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_DETECTIVE, JOB_CORRECTIONS_OFFICER)
+	restricted_roles = list(
+		JOB_BLUESHIELD,
+		JOB_HEAD_OF_SECURITY,
+		JOB_SECURITY_OFFICER,
+		JOB_WARDEN,
+		JOB_DETECTIVE,
+		JOB_CORRECTIONS_OFFICER,
+		JOB_VETERAN_ADVISOR,
+		JOB_QUARTERMASTER,
+		JOB_CAPTAIN,
+		JOB_BRIDGE_ASSISTANT,
+		JOB_ORDERLY,
+		JOB_ENGINEERING_GUARD,
+		JOB_CUSTOMS_AGENT,
+		JOB_SCIENCE_GUARD,
+		JOB_BOUNCER
+		)
+	// THE FLUFFY FRONTIER EDIT END
 
 /datum/loadout_item/suit/brasspriest
 	name = "Brasspriest Coat"


### PR DESCRIPTION
## О Pull Request

Теперь Caligram Armored Tan Parka доступна не только кучке ролей, на которых ее не носят, но и ролям, на которых ее в принципе можно использовать (+КМ, охрана отделов, ветеран и ассистент мостика)
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Механически - никак. Эта парка не дает никакой брони, поэтому только визуальные изменения. Позволит лучше самовыражаться людям!
## Доказательства тестирования
<details>
<summary>Скриншоты</summary>
  
![image](https://github.com/user-attachments/assets/1419158e-af10-430d-892a-3a2bf017fbf2)

</details>

## Changelog
:cl:
balance: Caligram Armored Tan Parka available for more roles in the loadout menu.
/:cl:
