### PR TITLE
GAS jobs blacklist update

### DIFF
--- a/tff_modular/master_files/code/modules/job/job_blacklist.dm
+++ b/tff_modular/master_files/code/modules/job/job_blacklist.dm
@@ -38,6 +38,9 @@
 /datum/job/engineering_guard
 	species_blacklist = list(SPECIES_NABBER = TRUE)
 
+/datum/job/telecomms_specialist
+	species_blacklist = list(SPECIES_NABBER = TRUE)
+
 //Медбэй
 /datum/job/chief_medical_officer
 	species_blacklist = list(SPECIES_NABBER = TRUE)
@@ -74,6 +77,9 @@
 /datum/job/customs_agent
 	species_blacklist = list(SPECIES_NABBER = TRUE)
 
+/datum/job/bitrunner
+	species_blacklist = list(SPECIES_NABBER = TRUE)
+
 //Сервис
 /datum/job/head_of_personnel
 	species_blacklist = list(SPECIES_NABBER = TRUE)
@@ -94,4 +100,11 @@
 	species_blacklist = list(SPECIES_NABBER = TRUE)
 
 /datum/job/bouncer
+	species_blacklist = list(SPECIES_NABBER = TRUE)
+
+//Особые должности
+/datum/job/veteran_advisor
+	species_blacklist = list(SPECIES_NABBER = TRUE)
+
+/datum/job/bridge_assistant
 	species_blacklist = list(SPECIES_NABBER = TRUE)


### PR DESCRIPTION
## О Pull Request

Добавляет в черный список должностей ГБСов новые профессии (ветеран СБ, ассистент мостика, битраннер и сисадмин)

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Плюсы:
\+ не нарушает логику расы

Минусы:
\- жуки не получат награды и уважения после битв в Гайе

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>
  
  
![ftchk1](https://github.com/user-attachments/assets/5e99ff97-432d-45eb-aaab-c6652723675e)


</details>

## Changelog


:cl: mogeoko
balance: Blacklisted new jobs for GAS
/:cl:
