### PR TITLE
owo юбочки для uwu сесурити

### DIFF
--- a/tff_modular/modules/redsec/code/vending.dm
+++ b/tff_modular/modules/redsec/code/vending.dm
@@ -42,6 +42,7 @@
 				/obj/item/storage/backpack/duffelbag/sec = 5,
 				/obj/item/clothing/under/rank/security/officer = 10,
 				/obj/item/clothing/under/rank/security/officer/skirt = 10,
+				/obj/item/clothing/under/rank/security/peacekeeper/plain_skirt = 10,
 				/obj/item/clothing/under/rank/security/peacekeeper = 10,
 				/obj/item/clothing/under/rank/security/nova/utility = 3,
 				/obj/item/clothing/shoes/jackboots/sec = 10,

--- a/tff_modular/modules/redsec_reskins/code/redsec.dm
+++ b/tff_modular/modules/redsec_reskins/code/redsec.dm
@@ -195,6 +195,18 @@
 			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/mob/clothing/under/security.dmi',
 			RESKIN_WORN_ICON_STATE = "security_skirt"
 		),
+		"Blue Jumpskirt" = list(
+			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/under/security.dmi',
+			RESKIN_ICON_STATE = "jumpskirt_blue",
+			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/mob/clothing/under/security.dmi',
+			RESKIN_ICON_STATE = "jumpskirt_blue"
+		),
+		"Black Jumpskirt" = list(
+			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/under/security.dmi',
+			RESKIN_ICON_STATE = "jumpskirt_black",
+			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/mob/clothing/under/security.dmi',
+			RESKIN_ICON_STATE = "jumpskirt_black"
+		),
 		"Red Skirt" = list(
 			RESKIN_ICON = 'icons/obj/clothing/under/security.dmi',
 			RESKIN_ICON_STATE = "secskirt",


### PR DESCRIPTION

## О Pull Request
У нас и в вендомате, и вообще была блюсек юбочка СБ, которая как туртлнек, но в альтскинах её были только баттлдресс и редсек. Я добавил к альтскинам саму имеющуюся юбочку + её черный вариант + plain вариант юбочки в вендомат.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру
+очки стиля
+возможность задирать рукава (раньше задрать рукава ты не мог, потому что в альтскинах не мог выбрать нужный вариант)

## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>
  
![изображение](https://github.com/user-attachments/assets/6c5bbdea-f067-4511-9136-eeef673cb6bf)
![изображение](https://github.com/user-attachments/assets/456b9754-0da0-4e1a-958a-7d0a59d1187d)
![изображение](https://github.com/user-attachments/assets/c962889b-ea75-4d73-8969-996178dfcfb9)

</details>

## Changelog
:cl:
add: adds bluesec skirt altskins and blusec plain skirt in vendomat
/:cl:
