### PR TITLE
Balance: prybar only in ruins

### DIFF
--- a/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
@@ -31,7 +31,8 @@
 	)
 
 // Crowbar that is completely normal except it can force doors
-
+// FF balance
+/*
 /datum/design/colony_door_crowbar
 	name = "Prybar"
 	id = "colony_prybar"
@@ -45,6 +46,7 @@
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED,
 	)
+*/
 
 // Welder that takes no fuel or power to run but is quite slow, at least it sounds cool as hell
 

--- a/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
@@ -4,10 +4,7 @@
 	description = "Contains all of the colony fabricator's tool designs."
 	design_ids = list(
 		"colony_power_drive",
-		// FLUFFY FRONTIER REMOVAL BEGIN - No public door openers
-		/*
-		"colony_prybar",
-		*/
+		// "colony_prybar", // FLUFFY FRONTIER REMOVAL
 		"colony_arc_welder",
 		"colony_compact_drill",
 	)

--- a/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
@@ -4,7 +4,10 @@
 	description = "Contains all of the colony fabricator's tool designs."
 	design_ids = list(
 		"colony_power_drive",
+		// FLUFFY FRONTIER REMOVAL BEGIN - No public door openers
+		/*
 		"colony_prybar",
+		*/
 		"colony_arc_welder",
 		"colony_compact_drill",
 	)

--- a/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
+++ b/modular_nova/modules/colony_fabricator/code/design_datums/tools.dm
@@ -31,7 +31,7 @@
 	)
 
 // Crowbar that is completely normal except it can force doors
-// FF balance
+// FLUFFY FRONTIER REMOVAL BEGIN - No public door openers
 /*
 /datum/design/colony_door_crowbar
 	name = "Prybar"
@@ -47,6 +47,7 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED,
 	)
 */
+// FLUFFY FRONTIER REMOVAL END
 
 // Welder that takes no fuel or power to run but is quite slow, at least it sounds cool as hell
 

--- a/modular_nova/modules/company_imports/code/armament_datums/akh_frontier.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/akh_frontier.dm
@@ -11,9 +11,12 @@
 /datum/armament_entry/company_import/akh_frontier/basic/omni_drill
 	item_type = /obj/item/screwdriver/omni_drill
 
+//FF balance
+/*
 /datum/armament_entry/company_import/akh_frontier/basic/prybar
 	item_type = /obj/item/crowbar/large/doorforcer
 	restricted = TRUE
+*/
 
 /datum/armament_entry/company_import/akh_frontier/basic/arc_welder
 	item_type = /obj/item/weldingtool/electric/arc_welder

--- a/modular_nova/modules/company_imports/code/armament_datums/akh_frontier.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/akh_frontier.dm
@@ -11,12 +11,13 @@
 /datum/armament_entry/company_import/akh_frontier/basic/omni_drill
 	item_type = /obj/item/screwdriver/omni_drill
 
-//FF balance
+// FLUFFY FRONTIER REMOVAL BEGIN - No public door openers
 /*
 /datum/armament_entry/company_import/akh_frontier/basic/prybar
 	item_type = /obj/item/crowbar/large/doorforcer
 	restricted = TRUE
 */
+// FLUFFY FRONTIER REMOVAL END
 
 /datum/armament_entry/company_import/akh_frontier/basic/arc_welder
 	item_type = /obj/item/weldingtool/electric/arc_welder


### PR DESCRIPTION

## О Pull Request

Ограничивает доступ к лому для вскрытия дверей. Ста кредитов и лёгкого крафта точно не должно быть для него.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Баланс открывашки, которую нельзя объяснить "Это жи ж лом!!1!" у какого-нибудь парамедика или офицера, что заказал себе за 100 кредитов.

## Доказательства тестирования

Код

## Changelog
:cl:
balance: Prybar was removed from Rapid Construction Fabricator and cargo imports. Now, it can be found only in ruins.
/:cl:
