### PR TITLE
Making max drones "-1"

### DIFF
--- a/tff_modular/modules/drone/code/droneDispenser.dm
+++ b/tff_modular/modules/drone/code/droneDispenser.dm
@@ -1,0 +1,7 @@
+/*
+	FF BALANCE: Drone production disabled
+	Для защиты от набегов и нарушителей
+*/
+
+/obj/machinery/drone_dispenser
+	maximum_idle = -1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8622,6 +8622,7 @@
 #include "tff_modular\modules\drinks\skrelluq\glass.dm"
 #include "tff_modular\modules\drinks\skrelluq\reaction.dm"
 #include "tff_modular\modules\drinks\skrelluq\reagent.dm"
+#include "tff_modular\modules\drone\code\droneDispenser.dm"
 #include "tff_modular\modules\holidays_decor\halloween\halloween-craft.dm"
 #include "tff_modular\modules\holidays_decor\halloween\halloween-decor.dm"
 #include "tff_modular\modules\holidays_decor\new_year\decorations.dm"


### PR DESCRIPTION
## О Pull Request

Отключение автоматического производства дронов выставлением максимума оболочек "-1".

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Защита от набегаторов и нарушителей на дронах.

## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

Вишня ЕРПшка требует видео именно тут

производит дронов только при изменении значения maximum_idle с -1 на любое другое

https://github.com/user-attachments/assets/290ab8e5-bbe5-4c44-afe0-2ba96d701608

</details>

## Changelog
:cl:
del: Maintenance drones now are unavailable
code: Changed max drone shells to "-1" 
/:cl:
