### PR TITLE
tweak(skrelluq): add some narcotic effect & reduce *wurble count

### DIFF
--- a/tff_modular/modules/drinks/skrelluq/reagent.dm
+++ b/tff_modular/modules/drinks/skrelluq/reagent.dm
@@ -10,7 +10,9 @@
 
 /datum/reagent/consumable/skrelluq/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	affected_mob.emote("wurble")
+	affected_mob.apply_status_effect(/datum/status_effect/stoned)
+	if(SPT_PROB(20, seconds_per_tick))
+		affected_mob.emote("wurble")
 
 /datum/reagent/consumable/skrelluq/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
## О Pull Request

Добавлен легкий наркотический эффект напитку Skrelluq и уменьшено количество *wurlbe за глоток до 2-3 (было 13).

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

(Мне точно не угрожали расправой за спам *wurble)

## Доказательства тестирования

Поверьте мне

## Changelog

:cl:
fix: tweak skrelluq *wurble count (2-3 per 5u) and added some narcotic effect
/:cl:

