### PR TITLE
Микроапдейт редсека

### DIFF
--- a/tff_modular/modules/redsec_reskins/code/redsec.dm
+++ b/tff_modular/modules/redsec_reskins/code/redsec.dm
@@ -288,6 +288,10 @@
 			RESKIN_ICON = 'icons/obj/clothing/shoes.dmi',
 			RESKIN_ICON_STATE = "jackboots",
 		),
+		"Red Variant" = list(
+			RESKIN_ICON = 'icons/obj/clothing/shoes.dmi',
+			RESKIN_ICON_STATE = "jackboots_sec",
+		)
 	)
 
 /obj/item/storage/backpack/duffelbag/sec/Initialize(mapload)
@@ -580,4 +584,22 @@
 			RESKIN_WORN_ICON = 'icons/mob/clothing/neck.dmi',
 			RESKIN_WORN_ICON_STATE = "hoscloak"
 		),
+	)
+
+//Разгрузка миротворца. Добавляется редсек вариант в виде спрайта разгрузки Армадайн ЕРТшников, которых... А их спавнили хоть раз?
+/obj/item/storage/belt/security/webbing/peacekeeper
+	uses_advanced_reskins = TRUE
+	unique_reskin = list(
+		"Blue Variant" = list(
+			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
+			RESKIN_ICON_STATE = "peacekeeper_webbing",
+			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
+			RESKIN_WORN_ICON_STATE = "peacekeeper_webbing"
+		),
+		"Red Variant" = list(
+			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
+			RESKIN_ICON_STATE = "armadyne_webbing",
+			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
+			RESKIN_WORN_ICON_STATE = "armadyne_webbing"
+		)
 	)

--- a/tff_modular/modules/redsec_reskins/code/redsec.dm
+++ b/tff_modular/modules/redsec_reskins/code/redsec.dm
@@ -603,15 +603,11 @@
 	uses_advanced_reskins = TRUE
 	unique_reskin = list(
 		"Blue Variant" = list(
-			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
 			RESKIN_ICON_STATE = "peacekeeper_webbing",
-			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
 			RESKIN_WORN_ICON_STATE = "peacekeeper_webbing"
 		),
 		"Red Variant" = list(
-			RESKIN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
 			RESKIN_ICON_STATE = "armadyne_webbing",
-			RESKIN_WORN_ICON = 'modular_nova/master_files/icons/obj/clothing/belts.dmi',
 			RESKIN_WORN_ICON_STATE = "armadyne_webbing"
 		)
 	)

--- a/tff_modular/modules/redsec_reskins/code/redsec.dm
+++ b/tff_modular/modules/redsec_reskins/code/redsec.dm
@@ -279,6 +279,21 @@
 		),
 	)
 
+/obj/item/storage/belt/security/webbing/peacekeeper/Initialize(mapload)
+	. = ..()
+	uses_advanced_reskins = TRUE
+	current_skin = NONE
+	unique_reskin = list(
+		"Red Variant" = list(
+			RESKIN_ICON_STATE = "armadyne_webbing",
+			RESKIN_WORN_ICON_STATE = "armadyne_webbing"
+		),
+		"Blue Variant" = list(
+			RESKIN_ICON_STATE = "peacekeeper_webbing",
+			RESKIN_WORN_ICON_STATE = "peacekeeper_webbing"
+		),
+	)
+
 /obj/item/clothing/shoes/jackboots/sec/Initialize(mapload)
 	. = ..()
 	unique_reskin += list(

--- a/tff_modular/modules/redsec_reskins/code/redsec.dm
+++ b/tff_modular/modules/redsec_reskins/code/redsec.dm
@@ -278,20 +278,6 @@
 			RESKIN_WORN_ICON_STATE = "belt_slim"
 		),
 	)
-/obj/item/storage/belt/security/webbing/peacekeeper/Initialize(mapload)
-	. = ..()
-	uses_advanced_reskins = TRUE
-	current_skin = NONE
-	unique_reskin = list(
-		"Red Variant" = list(
-			RESKIN_ICON_STATE = "armadyne_webbing",
-			RESKIN_WORN_ICON_STATE = "armadyne_webbing"
-		),
-		"Blue Variant" = list(
-			RESKIN_ICON_STATE = "peacekeeper_webbing",
-			RESKIN_WORN_ICON_STATE = "peacekeeper_webbing"
-		),
-	)
 
 /obj/item/clothing/shoes/jackboots/sec/Initialize(mapload)
 	. = ..()

--- a/tff_modular/modules/redsec_reskins/code/redsec.dm
+++ b/tff_modular/modules/redsec_reskins/code/redsec.dm
@@ -252,6 +252,18 @@
 			RESKIN_WORN_ICON = 'icons/mob/clothing/hands.dmi',
 			RESKIN_WORN_ICON_STATE = "black"
 		),
+		"Red Old Gloves" = list(
+			RESKIN_ICON = 'icons/obj/clothing/gloves.dmi',
+			RESKIN_ICON_STATE = "sec",
+			RESKIN_WORN_ICON = 'icons/mob/clothing/hands.dmi',
+			RESKIN_WORN_ICON_STATE = "sec"
+		),
+		"Blu Old Gloves" = list(
+			RESKIN_ICON = 'icons/obj/clothing/gloves.dmi',
+			RESKIN_ICON_STATE = "sec_blu",
+			RESKIN_WORN_ICON = 'icons/mob/clothing/hands.dmi',
+			RESKIN_WORN_ICON_STATE = "sec_blu"
+		)
 	)
 
 /obj/item/storage/belt/security/Initialize(mapload)

--- a/tff_modular/modules/redsec_reskins/code/redsec.dm
+++ b/tff_modular/modules/redsec_reskins/code/redsec.dm
@@ -279,21 +279,6 @@
 		),
 	)
 
-/obj/item/storage/belt/security/webbing/peacekeeper/Initialize(mapload)
-	. = ..()
-	uses_advanced_reskins = TRUE
-	current_skin = NONE
-	unique_reskin = list(
-		"Red Variant" = list(
-			RESKIN_ICON_STATE = "armadyne_webbing",
-			RESKIN_WORN_ICON_STATE = "armadyne_webbing"
-		),
-		"Blue Variant" = list(
-			RESKIN_ICON_STATE = "peacekeeper_webbing",
-			RESKIN_WORN_ICON_STATE = "peacekeeper_webbing"
-		),
-	)
-
 /obj/item/clothing/shoes/jackboots/sec/Initialize(mapload)
 	. = ..()
 	unique_reskin += list(
@@ -602,7 +587,12 @@
 //Разгрузка миротворца. Добавляется редсек вариант в виде спрайта разгрузки Армадайн ЕРТшников, которых... А их спавнили хоть раз?
 /obj/item/storage/belt/security/webbing/peacekeeper
 	uses_advanced_reskins = TRUE
-	unique_reskin = list(
+	current_skin = NONE
+	unique_reskin = list()
+
+/obj/item/storage/belt/security/webbing/peacekeeper/Initialize(mapload)
+	. = ..()
+	unique_reskin = list( //re-redefine of belt/security skins
 		"Blue Variant" = list(
 			RESKIN_ICON_STATE = "peacekeeper_webbing",
 			RESKIN_WORN_ICON_STATE = "peacekeeper_webbing"


### PR DESCRIPTION
## О Pull Request
Фикс и добавление редсек вариации для ботинков и разгрузки миротворца. Также добавлены ред- и блусек перчатки с ТГ. Технически, редсек вариация разгрузки - версия разгрузки для ЕРТ Армадайна, но их никогда никто не видел у нас на сервере. Это миф.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

БОЛЬШЕ РЕДСЕКА БОГУ РЕДСЕКА
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

![dreamseeker_8oD95zNU83](https://github.com/user-attachments/assets/b7cac52f-54e4-487e-8fcc-9a8d5ffdda0a)

![dreamseeker_zUYRG7divf](https://github.com/user-attachments/assets/f37d3bde-197e-4eab-9a43-7987a799031d)

</details>

## Changelog
:cl:
add: Added redsec versions for security boots and peacekeeprs webbings.
add: Added TG security gloves as new skins.
/:cl:
