### PR TITLE
"Фикс" авточейнджлогов

### DIFF
--- a/.github/workflows/auto_changelog.yml
+++ b/.github/workflows/auto_changelog.yml
@@ -33,4 +33,4 @@ jobs:
         script: |
           const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
           await processAutoChangelog({ github, context })
-        github-token: ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }}
+        github-token: ${{ steps.app-token-generation.outputs.token || secrets.SKYRATBOT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -70,4 +70,4 @@ jobs:
         if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token-generation.outputs.token || secrets.SKYRATBOT_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -59,4 +59,4 @@ jobs:
         pr_body: "This pull request updates the TGS DMAPI to the latest version. Please note any changes that may be breaking or unimplemented in your codebase by checking what changes are in the definitions file: code/__DEFINES/tgs.dm before merging.\n\n${{ steps.dmapi-update.outputs.release-notes }}"
         pr_label: "Tools"
         pr_allow_empty: false
-        github_token: ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }}
+        github_token: ${{ steps.app-token-generation.outputs.token || secrets.SKYRATBOT_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

## О Pull Request
Лень - двигатель прогресса. Но в данном случае - его стопор. Мы не используем этот `actions/create-github-app-token` и чейнджлоги у нас вообще генерируются под профилем вишни. Оставим пока как есть - то есть, вернём старую переменную секрета.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
