### PR TITLE
Возвращение стоимости в заниях спелла на реролл целей еретика

### DIFF
--- a/modular_nova/master_files/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -1,3 +1,3 @@
-// Allow to pick reroll ritual for free. Still needs to do a ritual with standard ingredients to reroll targets
+/* // Allow to pick reroll ritual for free. Still needs to do a ritual with standard ingredients to reroll targets
 /datum/heretic_knowledge/reroll_targets
-	cost = 0
+	cost = 0 */

--- a/modular_nova/master_files/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/modular_nova/master_files/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -1,3 +1,3 @@
 /* // Allow to pick reroll ritual for free. Still needs to do a ritual with standard ingredients to reroll targets
 /datum/heretic_knowledge/reroll_targets
-	cost = 0 */
+	cost = 0 */ // FLUFFY FRONTIER REMOVAL


### PR DESCRIPTION

## О Pull Request
https://github.com/Fluffy-Frontier/FluffySTG/pull/3520
Отключает модулярную правку анвара с Новы. Она теперь не имеет смысла, так как защиты дорм у нас уже давно нет.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Еретики больше не будут получать фри вознесение просто потому, что они каждую "сложную" цель заменили на "простую".
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
:cl:
balance: heretic target reroll once again costs knowledge to perform
/:cl:
