### PR TITLE
[TM-ONLY?] Фикс спавна руды

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -152,7 +152,7 @@
 		return ORE_WALL_LOW
 	if(distance < VENT_PROX_FAR)
 		return ORE_WALL_FAR
-	return 0
+	return rand(1,5) // FLUFFY FRONTIER EDIT - mineralAmt FIX. ORIGINAL return 0
 
 /turf/closed/mineral/get_smooth_underlay_icon(mutable_appearance/underlay_appearance, turf/asking_turf, adjacency_dir)
 	if(turf_type)


### PR DESCRIPTION

## О Pull Request
Если венты на лаваленде или айсленде плохо спавнятся, турфы с рудой могут иметь количетсво равное нулю и тупо не дропать ничего, хотя по сканеру они видны. Почему ТМ? в идеале - это баг апстрима и фиксить надо сверху, но изящное решение я пока не придумал (причина: лень)
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Шахтёры смогут добывать руду.
## Доказательства тестирования

Не будет, это сложно воспроизвести.

## Changelog
:cl:
fix: fixed ores not spawning in certain circumstances
/:cl:
