### PR TITLE
Небольшой ремап NSS Journey / Box Station.

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -1827,9 +1827,7 @@
 	},
 /area/station/construction/mining/aux_base)
 "arG" = (
-/obj/structure/table/wood/fancy/blue{
-	dir = s
-	},
+/obj/structure/table/wood/fancy/blue,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
@@ -4446,8 +4444,7 @@
 "aGp" = (
 /obj/machinery/shower/directional/west,
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/structure/drain,
 /turf/open/floor/iron/white/small,
@@ -18209,9 +18206,7 @@
 /area/station/maintenance/disposal/incinerator)
 "bJQ" = (
 /obj/structure/window/spawner/directional/west,
-/obj/structure/table/wood/fancy/blue{
-	dir = s
-	},
+/obj/structure/table/wood/fancy/blue,
 /obj/item/flashlight/lamp{
 	pixel_y = 5
 	},
@@ -25881,9 +25876,7 @@
 /obj/structure/window/reinforced/spawner/directional/west{
 	dir = 2
 	},
-/obj/structure/table/wood/fancy/blue{
-	dir = s
-	},
+/obj/structure/table/wood/fancy/blue,
 /obj/item/radio/intercom{
 	broadcasting = 1;
 	dir = 8;
@@ -27718,8 +27711,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
@@ -28573,8 +28565,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -31732,8 +31723,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/herringbone,
@@ -32226,8 +32216,7 @@
 	pixel_y = -4
 	},
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -33760,9 +33749,7 @@
 	req_access = list("brig");
 	dir = 2
 	},
-/obj/structure/table/wood/fancy/blue{
-	dir = s
-	},
+/obj/structure/table/wood/fancy/blue,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/gavelhammer,
 /obj/machinery/digital_clock{
@@ -37064,9 +37051,7 @@
 /obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
-/obj/structure/table/wood/fancy/blue{
-	dir = s
-	},
+/obj/structure/table/wood/fancy/blue,
 /obj/item/table_clock{
 	pixel_y = 5
 	},
@@ -39433,8 +39418,7 @@
 /obj/structure/table,
 /obj/item/storage/medkit/brute,
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -43411,8 +43395,7 @@
 "mcS" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
@@ -46179,9 +46162,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "nQe" = (
-/obj/structure/table/wood/fancy/blue{
-	dir = s
-	},
+/obj/structure/table/wood/fancy/blue,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
@@ -46993,8 +46974,7 @@
 /area/station/security/courtroom)
 "oqm" = (
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48957,8 +48937,7 @@
 /area/station/security/mechbay)
 "pxB" = (
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -51465,8 +51444,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -52057,8 +52035,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -53964,8 +53941,7 @@
 /area/station/maintenance/department/electrical)
 "sJO" = (
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54692,8 +54668,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/white{
-	dir = 4;
-	color = ы
+	dir = 4
 	},
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -31353,9 +31353,6 @@
 	reagent_list = list(/datum/reagent/water=600)
 	},
 /obj/structure/flora/rock/pile/jungle/style_random,
-/mob/living/basic/lightgeist{
-	name = "xeelorh"
-	},
 /turf/open/floor/plating/cobblestone,
 /area/station/service/bar)
 "eLM" = (

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -849,7 +849,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
@@ -25873,9 +25872,6 @@
 /area/station/hallway/secondary/entry)
 "cyc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 2
-	},
 /obj/structure/table/wood/fancy/blue,
 /obj/item/radio/intercom{
 	broadcasting = 1;
@@ -25889,6 +25885,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "cyg" = (
@@ -31208,9 +31205,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "eJr" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing{
 	name = "wooden railing";
@@ -31219,6 +31213,7 @@
 	},
 /obj/structure/table/wood/fancy,
 /obj/item/instrument/violin,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_half";
 	dir = 4
@@ -33744,11 +33739,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "goT" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Court";
-	req_access = list("brig");
-	dir = 2
-	},
 /obj/structure/table/wood/fancy/blue,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/gavelhammer,
@@ -33757,6 +33747,11 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Court";
+	req_access = list("brig");
+	dir = 2
 	},
 /turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
@@ -37045,12 +37040,6 @@
 /turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "ijT" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 2
-	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/structure/table/wood/fancy/blue,
 /obj/item/table_clock{
 	pixel_y = 5
@@ -37058,6 +37047,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "ijY" = (
@@ -38220,13 +38211,10 @@
 /obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
-/obj/machinery/door/window/left/directional/west{
-	name = "Fitness Ring";
-	dir = 1
-	},
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/door/window/left/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "iXa" = (
@@ -42257,15 +42245,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "luG" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Judge";
-	dir = 8;
-	req_access = list("brig")
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/door/window/brigdoor/left/directional/west,
 /turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "luH" = (
@@ -43050,6 +43034,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/ordnance/bomb)
+"lQV" = (
+/obj/machinery/door/window/left/directional/north,
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/station/holodeck/rec_center)
 "lRe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_blue,
@@ -43125,12 +43115,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "lTG" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_half";
 	dir = 8
@@ -45155,9 +45143,6 @@
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "nnO" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -45165,6 +45150,7 @@
 	color = "#8a3033";
 	dir = 4
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_half";
 	dir = 8
@@ -45627,7 +45613,6 @@
 /area/station/medical/medbay/aft)
 "nCw" = (
 /obj/structure/table/wood/fancy,
-/obj/structure/table/wood/fancy,
 /obj/structure/railing{
 	name = "wooden railing";
 	color = "#784936";
@@ -45885,7 +45870,6 @@
 	fax_name = "Crew Complaints";
 	name = "Crew Complaints Fax"
 	},
-/obj/structure/table,
 /obj/item/folder,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
@@ -48286,14 +48270,12 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "pdQ" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/comfy{
 	color = "#8a3033";
 	dir = 1
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_half";
 	dir = 4
@@ -48345,9 +48327,6 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "peW" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/machinery/restaurant_portal/bar,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -48357,6 +48336,7 @@
 	color = "#784936";
 	dir = 9
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_half";
 	dir = 8
@@ -53038,9 +53018,6 @@
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
 "sgb" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/machinery/computer/centcom_announcement/nri_raider{
 	name = "Judge announcement console";
 	desc = "A console used for making priority Internal Affairs reports.";
@@ -53056,6 +53033,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "sgl" = (
@@ -101501,7 +101479,7 @@ aro
 aro
 aro
 aro
-aro
+lQV
 rQR
 oJU
 oJU

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -44454,9 +44454,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "mRr" = (
@@ -58173,9 +58171,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "vlf" = (
-/obj/structure/window/reinforced/spawner/directional/south{
-	pixel_y = -4
-	},
 /obj/structure/chair{
 	name = "Defendant"
 	},
@@ -58185,8 +58180,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south{
+	pixel_y = -4
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
@@ -59556,10 +59552,8 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /obj/machinery/door/window/brigdoor/right/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "wdA" = (

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -24,12 +24,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	icon_state = "tile_half_contrasted"
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 1
-	},
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "aav" = (
@@ -1885,17 +1883,13 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/door/window/left/directional/south{
-	name = "Court Cell";
-	req_access = list("brig");
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/door/window/left/directional/north,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -24551,12 +24545,10 @@
 	icon_state = "tile_half_contrasted";
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "csd" = (
@@ -29324,10 +29316,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/left/directional/west{
-	name = "Fitness Ring";
-	dir = 2
-	},
+/obj/machinery/door/window/left/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "dCe" = (
@@ -32056,12 +32045,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	icon_state = "tile_half_contrasted"
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 1
-	},
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "fjm" = (
@@ -33748,11 +33735,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Court";
-	req_access = list("brig");
-	dir = 2
-	},
+/obj/machinery/door/window/brigdoor/left/directional/south,
 /turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "goX" = (
@@ -35955,9 +35938,7 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/prison/safe)
 "hBQ" = (
-/obj/machinery/door/airlock/security{
-	name = "Court maintenance"
-	},
+/obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38208,13 +38189,11 @@
 	icon_state = "tile_corner";
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/machinery/door/window/left/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "iXa" = (
@@ -41944,9 +41923,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/security{
-	name = "Court maintenance"
-	},
+/obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
@@ -42045,10 +42022,8 @@
 	icon_state = "tile_half_contrasted";
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 2
-	},
 /obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "lmF" = (
@@ -46788,9 +46763,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "oiB" = (
-/obj/machinery/door/airlock/security{
-	name = "Court maintenance"
-	},
+/obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -47123,12 +47096,10 @@
 	icon_state = "tile_corner"
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 1
-	},
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "otF" = (
@@ -54841,16 +54812,12 @@
 	icon_state = "tile_corner";
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 2
-	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/structure/railing{
 	dir = 6
 	},
 /obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "tiR" = (
@@ -59204,9 +59171,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/east{
-	dir = 1
-	},
 /obj/structure/chair/comfy{
 	color = "#8a3033";
 	dir = 1
@@ -59592,14 +59556,10 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/door/window/brigdoor/right/directional/west{
-	name = "Security Delivery";
-	req_access = list("brig");
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
+/obj/machinery/door/window/brigdoor/right/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "wdA" = (

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -24711,9 +24711,13 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "csZ" = (
-/turf/open/floor/wood/tile{
-	icon_state = "wood_large"
+/obj/structure/chair/sofa/left{
+	color = "#4465a6"
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "cta" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -25973,11 +25977,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "cyP" = (
-/obj/structure/chair/sofa/left{
+/obj/structure/chair/sofa/corner{
+	dir = 2;
+	light_color = null;
 	color = "#4465a6"
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
@@ -28615,12 +28621,11 @@
 	},
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
-/obj/structure/table,
 /obj/item/storage/briefcase/secure{
 	pixel_x = -7;
 	pixel_y = 12
 	},
-/obj/item/storage/box/evidence,
+/obj/machinery/rnd/production/techfab/department/security,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ddq" = (
@@ -33109,25 +33114,19 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "fUT" = (
-/obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/entertainment/plushie{
 	pixel_y = 16
 	},
+/obj/structure/table,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "fUX" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_half"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/maintenance/fore/lesser)
 "fVk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -33930,13 +33929,23 @@
 	},
 /area/station/holodeck/rec_center)
 "gua" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	location = "Security"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/iron/dark,
-/area/station/security/detectives_office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/door/airlock/corporate{
+	name = "Court Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "gui" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -35092,23 +35101,17 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "hei" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/door/airlock/corporate{
-	name = "Court Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/structure/cable,
-/turf/open/floor/iron/dark{
-	icon_state = "textured_dark_large"
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
 	},
-/area/station/maintenance/fore/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "hep" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -35486,11 +35489,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "hns" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark{
-	icon_state = "textured_dark_half"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	location = "Security"
 	},
-/area/station/maintenance/fore/lesser)
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/iron/dark,
+/area/station/security/detectives_office)
 "hnt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36989,6 +36994,13 @@
 	icon_state = "wood_parquet"
 	},
 /area/station/maintenance/port/fore)
+"iix" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/ammo_workbench,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "iiB" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -51439,17 +51451,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rch" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
+/turf/open/floor/wood/tile{
+	icon_state = "wood_large"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/detectives_office)
 "rcv" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
@@ -53416,6 +53421,14 @@
 "srx" = (
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"srD" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/box/evidence,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "srI" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -58002,7 +58015,7 @@
 /area/station/maintenance/port/aft)
 "veX" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/ammo_workbench,
+/obj/structure/table,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "vfi" = (
@@ -62216,16 +62229,17 @@
 	},
 /area/station/hallway/secondary/exit)
 "xNa" = (
-/obj/structure/chair/sofa/corner{
-	dir = 2;
-	light_color = null;
-	color = "#4465a6"
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/carpet/blue,
-/area/station/security/detectives_office)
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "xNc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -86850,7 +86864,7 @@ aUl
 aUl
 aUl
 adR
-wPx
+iix
 iVu
 xjQ
 fBM
@@ -87107,7 +87121,7 @@ iVu
 cky
 hIH
 adR
-wPx
+srD
 pgj
 rMz
 iVu
@@ -88929,7 +88943,7 @@ tcz
 uHO
 uca
 tcz
-fUX
+xNa
 kDW
 wYB
 pVZ
@@ -89186,7 +89200,7 @@ kFq
 kFq
 kFq
 kFq
-rch
+hei
 wdv
 wYB
 xLC
@@ -89444,7 +89458,7 @@ aiX
 aiX
 aiX
 wYB
-gua
+hns
 wYB
 gmK
 wYB
@@ -89702,7 +89716,7 @@ vRY
 aiX
 mPd
 hGW
-csZ
+rch
 uOe
 wYB
 jQz
@@ -89957,7 +89971,7 @@ cCB
 qUT
 hkA
 aiX
-cyP
+csZ
 tSc
 adu
 uOe
@@ -90728,7 +90742,7 @@ vad
 nJO
 kUI
 aiX
-xNa
+cyP
 huh
 adu
 nGc
@@ -96381,7 +96395,7 @@ hfM
 aaU
 xHD
 anF
-hei
+gua
 ajm
 miY
 ajp
@@ -96635,7 +96649,7 @@ kxi
 viO
 mwk
 oOI
-hns
+fUX
 nas
 gOB
 aiA

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -31313,7 +31313,6 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "eKV" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
@@ -50127,7 +50126,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "qnW" = (
@@ -56399,8 +56397,6 @@
 /turf/open/space/basic,
 /area/station/solars/port/fore)
 "ufL" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/item/kirbyplants/synthetic/plant28,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -57054,10 +57050,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
-"uBY" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "uDg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -61205,7 +61197,9 @@
 	},
 /obj/structure/cable,
 /obj/structure/barricade/wooden/crude,
-/obj/machinery/door/puzzle/keycard/library,
+/obj/machinery/door/airlock/maintenance{
+	name = "Garden Maintenance"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "xac" = (
@@ -79709,7 +79703,7 @@ aFO
 aHA
 azF
 ufL
-uBY
+aLE
 avG
 aOl
 aPA

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -21,8 +21,14 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
 "aap" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_half_contrasted"
+	},
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
@@ -79,6 +85,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"aaU" = (
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_corner"
+	},
+/area/station/maintenance/fore/lesser)
 "aaZ" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
@@ -121,8 +132,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/item/kirbyplants/synthetic/plant27,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "abB" = (
 /obj/structure/dresser,
@@ -512,14 +533,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
+/turf/open/floor/carpet/blue,
 /area/station/service/theater)
 "afg" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -657,8 +676,11 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "ahn" = (
-/turf/closed/wall,
-/area/station/maintenance/fore/lesser)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "ahx" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -682,13 +704,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "ahY" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/two,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
-	dir = 4
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "aig" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -758,13 +779,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aiR" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aiX" = (
@@ -815,14 +842,35 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/bomb)
 "ajm" = (
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/door/window/left/directional/south{
+	name = "Court Cell";
+	req_access = list("brig");
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "ajo" = (
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "ajp" = (
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "ajq" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -1041,7 +1089,10 @@
 /area/station/hallway/secondary/exit)
 "alg" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "ali" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1122,9 +1173,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "amr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/courtroom)
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "amv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -1228,11 +1283,15 @@
 /area/station/cargo/office)
 "anc" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/machinery/light/directional/south{
+	dir = 4
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "ane" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -1285,10 +1344,37 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
+	},
+/obj/structure/chair{
+	name = "Defendant"
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "anF" = (
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/table/reinforced,
+/obj/machinery/coffeemaker{
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/cup/coffeepot{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 8
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "anH" = (
 /obj/structure/sign/warning/electric_shock,
@@ -1349,6 +1435,8 @@
 	c_tag = "Fore Port Solar Access"
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aok" = (
@@ -1480,7 +1568,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "apB" = (
 /obj/machinery/camera/directional/south{
@@ -1619,6 +1710,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aqO" = (
@@ -1655,6 +1747,12 @@
 "aqR" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"aqU" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large{
+	icon_state = "wood_tile"
+	},
+/area/station/service/bar)
 "aqW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1726,6 +1824,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	color = "#777575";
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "arE" = (
@@ -1741,11 +1843,20 @@
 	},
 /area/station/construction/mining/aux_base)
 "arG" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
+/obj/structure/table/wood/fancy/blue{
+	dir = s
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_y = 15
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "arK" = (
 /obj/structure/window/spawner/directional/east,
@@ -1788,8 +1899,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "asb" = (
-/obj/structure/trash_pile,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/window/left/directional/south{
+	name = "Court Cell";
+	req_access = list("brig");
+	dir = 1
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "asd" = (
 /obj/machinery/door/airlock/maintenance{
@@ -1805,6 +1927,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -1902,6 +2028,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"asS" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "asU" = (
 /turf/open/floor/plating/airless,
 /area/station/solars/port/fore)
@@ -1965,14 +2096,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/starboard/fore)
 "atr" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Garden Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/xeno,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "atw" = (
@@ -2095,11 +2221,6 @@
 /area/station/maintenance/port/fore)
 "atV" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "atW" = (
@@ -2407,16 +2528,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "avw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Fitness Maintenance"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "avB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -2582,14 +2698,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
+/obj/structure/closet/masks,
 /turf/open/floor/iron/dark/side{
-	dir = 1
+	dir = 5
 	},
-/area/station/commons/dorms)
+/area/station/commons/fitness)
 "awD" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -2854,19 +2971,34 @@
 "axQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4;
+	icon_state = "darkcorner"
+	},
+/area/station/commons/fitness)
 "axV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "axX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/chair/pew/right{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 2
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "ayb" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -3099,6 +3231,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "azl" = (
@@ -3235,9 +3370,13 @@
 /turf/closed/wall,
 /area/station/commons/toilet)
 "aAo" = (
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/area/station/commons/fitness)
 "aAp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3290,6 +3429,10 @@
 "aAx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aAz" = (
@@ -3364,25 +3507,49 @@
 /area/station/maintenance/port/fore)
 "aAP" = (
 /obj/machinery/seed_extractor,
-/turf/open/floor/iron,
+/obj/item/seeds/watermelon,
+/obj/item/seeds/tower,
+/obj/item/seeds/wheat,
+/obj/item/seeds/sugarcane,
+/obj/item/seeds/orange,
+/obj/item/seeds/grape,
+/obj/item/seeds/cocoapod,
+/obj/item/seeds/banana,
+/obj/item/seeds/apple,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/hydroponics/garden)
 "aAQ" = (
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aAS" = (
-/obj/structure/sink/directional/south,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	icon_state = "wood_tile"
+	},
+/area/station/maintenance/port/fore)
 "aAT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/item/storage/box/matches{
+	pixel_x = 10;
+	pixel_y = 15
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood_tile"
+	},
+/area/station/maintenance/port/fore)
 "aAU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "aAV" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
@@ -3472,14 +3639,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aBy" = (
-/obj/machinery/door/airlock{
-	id_tag = null;
-	name = "Unit 3"
+/obj/machinery/light/small/directional/west{
+	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/urinal/directional/north,
+/obj/structure/urinal/directional/north,
+/obj/structure/urinal/directional/north,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aBz" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -3502,12 +3679,17 @@
 /area/station/commons/dorms)
 "aBB" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 5
+	},
+/obj/item/kirbyplants/synthetic/plant29,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "aBC" = (
 /obj/structure/disposalpipe/sorting/mail,
@@ -3533,6 +3715,11 @@
 "aBG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/item/reagent_containers/cup/bucket,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -3567,7 +3754,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aBM" = (
-/obj/effect/landmark/start/assistant,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aBN" = (
@@ -3751,22 +3944,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "aDg" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/structure/table/glass,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/tower,
-/obj/item/seeds/wheat,
-/obj/item/seeds/sugarcane,
-/obj/item/seeds/orange,
-/obj/item/seeds/grape,
-/obj/item/seeds/cocoapod,
-/obj/item/seeds/banana,
-/obj/item/seeds/apple,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/jungle/b/style_random{
+	pixel_y = -15;
+	pixel_x = -3
+	},
+/turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "aDh" = (
 /obj/machinery/vending/assist,
@@ -3779,6 +3964,14 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"aDu" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/structure/urinal/directional/north,
+/turf/open/floor/iron/white/small,
+/area/station/commons/toilet)
 "aDA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -3795,12 +3988,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "aDH" = (
 /obj/machinery/door/firedoor/heavy,
@@ -3836,11 +4024,24 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aDQ" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet1";
-	name = "Unit 1"
+/obj/machinery/button/door{
+	id = "Toilet1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
+	},
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/obj/item/newspaper{
+	pixel_x = 7;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aDR" = (
 /obj/structure/table/wood,
@@ -3851,16 +4052,20 @@
 	},
 /obj/item/food/baguette,
 /obj/item/toy/dummy,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "aDT" = (
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aDX" = (
 /obj/structure/chair/sofa/bench/right,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "aEa" = (
 /obj/structure/cable,
@@ -3967,15 +4172,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/camera/directional/east{
-	c_tag = "Dormitory South"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "aFe" = (
 /obj/structure/cable,
@@ -3987,19 +4184,18 @@
 	},
 /area/station/commons/dorms)
 "aFl" = (
-/obj/structure/table/wood,
-/obj/item/lipstick/random{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lipstick/random{
-	pixel_x = -2;
-	pixel_y = -2
-	},
 /obj/structure/mirror/directional/west,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/bed/pod,
+/obj/item/pillow/mime{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/bedsheet/mime,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "aFm" = (
 /obj/structure/disposalpipe/segment{
@@ -4012,7 +4208,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aFn" = (
 /obj/structure/closet/emcloset,
@@ -4104,12 +4300,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aFO" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Garden"
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/reagent_containers/spray/pestspray{
+	pixel_x = 3;
+	pixel_y = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/cup/bottle/nutrient/ez,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/bottle/nutrient/rh{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/hydroponics/garden)
 "aFP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -4117,6 +4321,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	color = "#777575";
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -4173,6 +4381,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"aFX" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "aFY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -4203,33 +4422,43 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aGk" = (
-/obj/structure/toilet{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/commons/dorms)
+"aGl" = (
 /obj/machinery/button/door{
-	id = "Toilet1";
+	id = "Toilet2";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
 	specialfunctions = 4
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/mineral/titanium/blue,
-/area/station/commons/toilet)
-"aGl" = (
-/obj/machinery/door/airlock{
-	id_tag = "Toilet2";
-	name = "Unit 2"
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aGn" = (
 /obj/machinery/shower/directional/east,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aGp" = (
 /obj/machinery/shower/directional/west,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aGs" = (
 /obj/machinery/requests_console{
@@ -4272,17 +4501,17 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "aGy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plastic,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aGB" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -4296,16 +4525,16 @@
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/kitchen,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aGD" = (
-/obj/structure/dresser,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/landmark/start/mime,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "aGE" = (
 /obj/structure/cable,
@@ -4326,30 +4555,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "aGH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_half"
 	},
-/obj/structure/cable,
+/area/station/maintenance/fore/lesser)
+"aGI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
-/area/station/hallway/secondary/service)
-"aGI" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plastic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aGO" = (
 /obj/structure/cable,
@@ -4367,10 +4588,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aGQ" = (
 /obj/structure/cable,
@@ -4384,7 +4602,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random/directional/south,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "aGU" = (
 /obj/machinery/requests_console{
@@ -4479,28 +4697,25 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "aHA" = (
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/reagent_containers/spray/pestspray{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/bottle/nutrient/ez,
-/obj/item/reagent_containers/cup/bottle/nutrient/rh{
-	pixel_x = 2;
-	pixel_y = 1
-	},
+/obj/item/storage/bag/plants/portaseeder,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/item/plant_analyzer,
+/obj/machinery/light_switch{
+	pixel_x = -6;
+	pixel_y = -25
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/crowbar,
+/obj/item/cultivator,
+/obj/item/hatchet,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light/directional/east{
+	dir = 2
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aHD" = (
 /obj/structure/chair/stool{
@@ -4526,29 +4741,20 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "aHI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/landmark/navigate_destination,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/closet/crate/wooden/toy,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "aHM" = (
 /obj/structure/cable,
@@ -4593,23 +4799,26 @@
 	},
 /area/station/commons/dorms)
 "aHY" = (
-/obj/effect/turf_decal/trimline/white/line,
-/turf/open/floor/iron/showroomfloor,
-/area/station/hallway/secondary/service)
-"aHZ" = (
-/obj/structure/closet/crate/wooden/toy,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 2
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#9FED58"
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/area/station/hallway/secondary/service)
+"aHZ" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "aIe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -4637,7 +4846,9 @@
 "aIl" = (
 /obj/structure/table,
 /obj/item/camera,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "aIp" = (
 /turf/closed/wall,
@@ -4750,23 +4961,16 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aIO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aIP" = (
-/obj/structure/table/glass,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/cup/bucket,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/machinery/hydroponics/soil,
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "aIR" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -4782,30 +4986,28 @@
 "aIS" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	color = "#777575"
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	color = "#777575";
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aIT" = (
-/obj/item/storage/bag/plants/portaseeder,
-/obj/structure/table/glass,
-/obj/item/plant_analyzer,
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = -25
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/structure/chair/comfy{
+	color = "#8a3033";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
 	},
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/crowbar,
-/obj/item/cultivator,
-/obj/item/hatchet,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/station/service/bar)
 "aIU" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -4848,19 +5050,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "aJg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aJn" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4953,10 +5146,16 @@
 	},
 /area/station/hallway/primary/central)
 "aJz" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/mineral/titanium/blue,
-/area/station/commons/toilet)
+/obj/machinery/light/directional/west,
+/obj/structure/chair/sofa/right{
+	color = "#8a3033";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/station/service/bar)
 "aJC" = (
 /turf/closed/wall,
 /area/station/service/bar)
@@ -5136,20 +5335,22 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aKn" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/service/hydroponics/garden)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "aKo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/chair/sofa/corner{
+	color = "#8a3033"
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 5
 	},
-/area/station/hallway/primary/central)
+/turf/open/floor/carpet/red,
+/area/station/service/bar)
 "aKp" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -5214,7 +5415,9 @@
 /area/station/service/hydroponics)
 "aKW" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "aKX" = (
 /obj/effect/turf_decal/loading_area,
@@ -5273,7 +5476,9 @@
 /area/station/service/chapel/office)
 "aLd" = (
 /obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "aLe" = (
 /obj/structure/chair{
@@ -5421,28 +5626,33 @@
 	c_tag = "Central Hallway North-East"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
 /area/station/hallway/primary/central)
 "aLR" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/north,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#5d341f";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "aLU" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe";
-	pixel_x = -4
-	},
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "aLX" = (
 /obj/effect/turf_decal/tile/blue{
@@ -5529,12 +5739,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aMp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/holodeck,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/computer/holodeck,
-/turf/open/floor/iron,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "aMs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -5640,11 +5855,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "aMN" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/smooth_large,
+/obj/structure/table,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "aMO" = (
 /obj/machinery/status_display/evac/directional/east,
@@ -5787,9 +6002,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "aNu" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/holosign_creator/robot_seat/bar,
-/turf/open/floor/wood,
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "aNL" = (
 /obj/machinery/door/firedoor,
@@ -5814,15 +6030,15 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
 "aNP" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
-	},
 /obj/structure/table,
 /obj/machinery/fax{
 	fax_name = "Service Hallway";
 	name = "Service Fax Machine"
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
+	},
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "aNQ" = (
 /obj/effect/spawner/structure/window,
@@ -6287,6 +6503,23 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"aPP" = (
+/obj/machinery/light/directional/west,
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "aPQ" = (
 /turf/closed/wall,
 /area/station/commons/storage/tools)
@@ -6471,7 +6704,9 @@
 /area/station/commons/locker)
 "aQX" = (
 /obj/machinery/photocopier,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "aQY" = (
 /obj/structure/table,
@@ -6567,12 +6802,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "aRo" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood{
+	icon_state = "wood_parquet"
 	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden)
+/area/station/maintenance/port/fore)
 "aRp" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/tile/blue,
@@ -6960,13 +7194,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms)
-"aTl" = (
-/obj/structure/railing/corner/end/flip,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"aTk" = (
+/obj/structure/sauna_oven,
+/turf/open/floor/wood{
+	icon_state = "wood_large"
 	},
-/turf/open/floor/iron,
-/area/station/security/mechbay)
+/area/station/maintenance/port/fore)
+"aTl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/item/banner/security{
+	name = "Prosecution banner";
+	warcry = "ПЕРМУ!!"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "aTm" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral,
@@ -8998,15 +9243,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bbV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
+/turf/open/floor/wood{
+	icon_state = "wood_tile"
 	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/station/maintenance/port/fore)
 "bbW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "heads_meeting";
@@ -10061,7 +10301,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bgq" = (
-/turf/open/floor/carpet/red,
+/obj/structure/broken_flooring/plating,
+/obj/structure/broken_flooring/plating{
+	icon_state = "pile"
+	},
+/turf/open/floor/plating,
 /area/station/security/execution/transfer)
 "bgr" = (
 /obj/machinery/door/airlock{
@@ -10941,7 +11185,7 @@
 /area/station/medical/morgue)
 "bkg" = (
 /obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "bkh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11309,11 +11553,15 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "blD" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "blH" = (
 /obj/structure/sink/directional/west,
@@ -14622,9 +14870,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
+/turf/open/floor/carpet/blue,
 /area/station/service/theater)
 "bxr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -16852,6 +17098,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"bFS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 10
+	},
+/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/light/directional/east{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/station/security/courtroom)
 "bFU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron/white,
@@ -17955,7 +18217,9 @@
 /area/station/maintenance/disposal/incinerator)
 "bJQ" = (
 /obj/structure/window/spawner/directional/west,
-/obj/structure/table/wood/fancy/blue,
+/obj/structure/table/wood/fancy/blue{
+	dir = s
+	},
 /obj/item/flashlight/lamp{
 	pixel_y = 5
 	},
@@ -19825,15 +20089,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bSp" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "bSs" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -23242,7 +23508,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/machinery/door/airlock/service{
+	name = "Bar Entrance"
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "ckb" = (
 /obj/machinery/meter,
@@ -23277,22 +23548,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ckA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/turf/open/floor/iron/stairs/old{
+	color = "#b0b0b0"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/commons/dorms)
+/area/station/commons/fitness)
 "ckB" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -23386,11 +23648,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/smartfridge/drinks,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
 	},
-/turf/open/floor/iron/dark/diagonal,
 /area/station/service/bar)
 "clf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23623,12 +23883,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "cnw" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
 /obj/item/cigbutt,
 /obj/effect/decal/cleanable/ash,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "cnx" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -23758,16 +24015,18 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
 "cpl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/service{
 	name = "Service Hall"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
-/turf/open/floor/plastic,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "cpq" = (
 /obj/structure/closet/toolcloset,
@@ -24074,17 +24333,21 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "cqO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/railing{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
 	},
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/south{
+	pixel_y = -4
 	},
-/turf/open/floor/iron/dark/side,
-/area/station/commons/dorms)
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "cqP" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/smooth_large,
@@ -24301,8 +24564,15 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "csc" = (
-/obj/structure/chair/sofa/corp/corner{
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_half_contrasted";
 	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
@@ -24452,15 +24722,11 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "csZ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/commons/fitness)
 "cta" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -25331,16 +25597,16 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cvU" = (
-/obj/machinery/door/airlock{
-	name = "Law Office"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination,
 /obj/machinery/door/firedoor,
-/turf/open/floor/wood/tile,
+/obj/machinery/door/airlock/security{
+	name = "Law Office"
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "cvV" = (
 /obj/structure/cable,
@@ -25555,25 +25821,20 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "cwF" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
+/obj/structure/chair/wood/wings{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/green/anticorner{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "cwQ" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/table/wood,
+/turf/open/floor/wood/tile,
 /area/station/security/courtroom)
 "cwT" = (
 /obj/item/beacon,
@@ -25625,11 +25886,26 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "cyc" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 2
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/table/wood/fancy/blue{
+	dir = s
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	dir = 8;
+	listening = 0;
+	name = "Station Intercom (Court)"
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_y = 20
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "cyg" = (
 /obj/machinery/door/airlock/command/glass{
@@ -26924,7 +27200,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/closed/wall,
 /area/station/commons/toilet)
 "cFI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27410,6 +27686,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/obj/item/poster/random_official,
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "cIP" = (
@@ -27421,10 +27704,21 @@
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
 "cJf" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
+/obj/structure/weightmachine,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "cJk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27524,7 +27818,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "cLN" = (
-/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "cMm" = (
@@ -27674,16 +27970,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "cOk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/commons/dorms)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "cOl" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -27830,14 +28121,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cRr" = (
-/obj/effect/turf_decal/siding/brown/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "cSk" = (
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/secondary/service)
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/structure/flora/bush/jungle/c/style_random{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/turf/open/floor/grass,
+/area/station/service/bar)
 "cSz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -28268,7 +28562,21 @@
 /area/station/engineering/main)
 "dch" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "dcl" = (
 /obj/structure/cable,
@@ -28434,6 +28742,7 @@
 	name = "Prisoner Processing"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "dhx" = (
@@ -28455,19 +28764,19 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "dii" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/plastic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "diu" = (
 /obj/structure/table/wood,
@@ -28514,10 +28823,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "djV" = (
-/obj/structure/railing{
-	dir = 1
+/turf/open/floor/wood/large{
+	icon_state = "wood_tile"
 	},
-/turf/open/floor/iron/white/herringbone,
 /area/station/service/bar)
 "dkB" = (
 /obj/machinery/door/airlock/external{
@@ -28548,21 +28856,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "dlp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8;
+	color = "#9FED58"
+	},
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "dlx" = (
 /obj/structure/punching_bag,
@@ -28645,11 +28953,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/mob/living/carbon/human/species/monkey/punpun,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "doY" = (
 /obj/machinery/requests_console/directional/north{
@@ -28741,7 +29050,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/hedge,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/station/service/bar)
 "dsd" = (
 /obj/machinery/computer/records/security{
@@ -29007,6 +29328,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"dBA" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_corner";
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/door/window/left/directional/west{
+	name = "Fitness Ring";
+	dir = 2
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "dCe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -29040,14 +29373,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dDa" = (
-/obj/item/radio/intercom/directional/north,
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
+/obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark/diagonal,
+/obj/machinery/chem_dispenser/drinks,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "dDi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29149,8 +29484,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "dGd" = (
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
+	},
+/obj/structure/flora/ocean/longseaweed,
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "dGY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29262,13 +29601,13 @@
 /area/station/command/heads_quarters/hos)
 "dJg" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/closet/secure_closet/freezer/cream_pie,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "dJk" = (
 /obj/machinery/camera/directional/south{
@@ -29371,11 +29710,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "dMf" = (
-/obj/structure/chair/sofa/left,
-/obj/effect/landmark/start/clown,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/obj/structure/table/wood,
+/obj/item/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
 	},
+/obj/item/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "dMy" = (
 /obj/structure/disposalpipe/segment{
@@ -29413,7 +29761,8 @@
 	c_tag = "Prison Isolation Cell";
 	network = list("ss13","prison","isolation")
 	},
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "dOK" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -29475,9 +29824,22 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "dPK" = (
-/obj/machinery/restaurant_portal/bar,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light/directional/west{
+	dir = 1
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark/end,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "dPM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -29512,11 +29874,15 @@
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "dQM" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "dRe" = (
@@ -29661,6 +30027,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"dWQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/hedge,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 5
+	},
+/turf/open/floor/grass,
+/area/station/service/bar)
 "dXE" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrous_input{
 	dir = 8
@@ -29766,8 +30144,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/genetics)
 "dZA" = (
-/obj/machinery/airalarm/directional/west,
-/obj/item/kirbyplants/random,
+/obj/structure/chair/comfy{
+	color = "#8a3033"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "dZJ" = (
@@ -29834,10 +30216,13 @@
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "eat" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/table/wood,
+/obj/item/fish/clownfish,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "eaI" = (
 /obj/effect/turf_decal/tile/red{
@@ -30178,7 +30563,11 @@
 "elT" = (
 /obj/machinery/shower/directional/west,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "emh" = (
 /obj/structure/chair{
@@ -30230,6 +30619,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"enW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "eoi" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -30503,17 +30898,23 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ezJ" = (
-/obj/structure/railing/corner/end{
-	dir = 8
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784938";
+	dir = 1
 	},
-/obj/structure/railing/corner/end/flip{
-	dir = 4
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 9
 	},
-/turf/open/floor/glass,
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
 /area/station/service/bar)
 "eAj" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/plastic,
+/obj/item/kirbyplants/random/fullysynthetic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "eAy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30543,7 +30944,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "eAU" = (
 /obj/effect/spawner/random/structure/grille,
@@ -30816,12 +31217,21 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "eJr" = (
-/obj/structure/flora/rock,
-/obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
 	},
-/obj/structure/window/spawner/directional/south,
-/turf/open/water/overlay,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 6
+	},
+/obj/structure/table/wood/fancy,
+/obj/item/instrument/violin,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 4
+	},
 /area/station/service/bar)
 "eJx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30902,6 +31312,25 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"eKV" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -7;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "eLk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30920,9 +31349,15 @@
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "eLI" = (
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
+	},
+/obj/structure/flora/rock/pile/jungle/style_random,
+/mob/living/basic/lightgeist{
+	name = "xeelorh"
+	},
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "eLM" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -31127,14 +31562,10 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "eSp" = (
-/obj/structure/table/wood,
 /obj/item/pen/red,
 /obj/item/taperecorder,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/wood/tile,
+/obj/structure/table/wood,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "eSQ" = (
 /obj/machinery/door/firedoor,
@@ -31295,18 +31726,38 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
 "faG" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark/side,
-/area/station/commons/fitness)
-"faM" = (
-/obj/effect/spawner/random/entertainment/arcade{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/railing,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
+"faM" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/end,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "fbE" = (
 /obj/machinery/door/morgue{
@@ -31330,6 +31781,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"fca" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 2
+	},
+/turf/open/floor/iron/dark/side,
+/area/station/commons/dorms)
 "fcw" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -31460,7 +31921,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/tile,
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "ffa" = (
 /obj/structure/tank_holder/oxygen/red,
@@ -31598,13 +32059,28 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "fjc" = (
+/obj/structure/hedge,
 /obj/structure/railing{
-	dir = 6
+	name = "wooden railing";
+	color = "#784936";
+	dir = 2
 	},
-/turf/open/floor/glass,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/station/service/bar)
 "fjj" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_half_contrasted"
+	},
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "fjm" = (
@@ -31650,20 +32126,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "fke" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/spawner/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/item/reagent_containers/cup/glass/bottle/vodka/badminka{
-	pixel_x = 6;
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/flora/rock/pile/jungle/style_random{
 	pixel_y = 7
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
-	pixel_y = 7;
-	pixel_x = -7
-	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/flora/bush/jungle/c/style_random,
+/turf/open/floor/grass,
 /area/station/service/bar)
 "fkf" = (
 /obj/machinery/door/airlock/maintenance,
@@ -31705,7 +32173,17 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#5d341f";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/station/commons/dorms)
 "flN" = (
 /obj/structure/sign/poster/official/science/directional/north,
@@ -31742,6 +32220,26 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"fnI" = (
+/obj/structure/rack/shelf,
+/obj/item/training_toolbox{
+	pixel_y = 6
+	},
+/obj/item/training_toolbox{
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "fnM" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
@@ -31765,11 +32263,17 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/science/robotics/lab)
+"fog" = (
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "fpc" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/railing,
+/obj/machinery/vending/cola/shamblers,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "fph" = (
@@ -31925,10 +32429,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "fyb" = (
-/obj/structure/railing{
-	dir = 9
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "fyz" = (
 /obj/machinery/firealarm/directional/east,
@@ -32068,38 +32572,46 @@
 /area/station/security/prison/workout)
 "fDD" = (
 /obj/structure/chair/sofa/bench/left,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "fDM" = (
+/obj/structure/chair/comfy{
+	color = "#8a3033"
+	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "fDX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark,
+/area/station/service/lawoffice)
 "fEM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "fFe" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/effect/turf_decal/tile/green/anticorner{
+/obj/structure/chair/wood/wings{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "fFB" = (
 /obj/structure/rack/wooden,
@@ -32108,10 +32620,10 @@
 /area/station/common/pool)
 "fFQ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
 	},
-/turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "fGg" = (
 /obj/structure/cable,
@@ -32172,17 +32684,19 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "fHR" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "fHV" = (
 /obj/structure/dresser,
@@ -32206,7 +32720,11 @@
 /area/station/security/prison/garden)
 "fIE" = (
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood/tile,
+/obj/effect/landmark/start/lawyer,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "fIG" = (
 /obj/machinery/computer/scan_consolenew{
@@ -32227,8 +32745,16 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "fJg" = (
-/obj/machinery/vending/games,
 /obj/machinery/light/directional/south,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 2
+	},
+/obj/structure/railing{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/dorms)
 "fJl" = (
@@ -32353,14 +32879,13 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fPh" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/circuitboard/machine/vendatray,
 /obj/item/circuitboard/machine/vendatray,
 /obj/item/toner/large,
-/turf/open/floor/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "fPm" = (
 /obj/structure/cable,
@@ -32374,9 +32899,18 @@
 /turf/open/floor/plating,
 /area/station/engineering/gravity_generator)
 "fPr" = (
-/obj/structure/table,
-/obj/item/storage/medkit,
-/turf/open/floor/iron,
+/obj/structure/weightmachine,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "fPC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -32392,15 +32926,13 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms)
 "fPV" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
+/obj/structure/chair/wood/wings{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 5
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/red,
 /area/station/security/courtroom)
 "fPX" = (
 /obj/structure/table,
@@ -32507,7 +33039,10 @@
 "fTd" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/obj/machinery/door/airlock/security,
+/obj/machinery/door/airlock/security{
+	id_tag = "IsolationCell";
+	name = "Isolation Cell"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "fTk" = (
@@ -32687,7 +33222,12 @@
 /area/station/medical/medbay/lobby)
 "fYk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/item/target,
+/obj/structure/training_machine,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "fYp" = (
 /obj/structure/cable,
@@ -32724,15 +33264,20 @@
 "fYT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/cigarette,
-/turf/open/floor/iron/dark/side{
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/chair{
 	dir = 1
 	},
-/area/station/commons/dorms)
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "fYZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -32853,9 +33398,17 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation)
 "gdE" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 2
+	},
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "gdI" = (
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -32876,14 +33429,11 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/port/fore)
 "geS" = (
-/obj/structure/hedge,
-/obj/structure/railing{
-	dir = 6
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/white/end{
-	dir = 4
-	},
-/turf/open/floor/grass,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "gfa" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -32927,6 +33477,10 @@
 "ghh" = (
 /turf/open/floor/plating/airless,
 /area/station/solars/port/aft)
+"gho" = (
+/obj/structure/broken_flooring/plating,
+/turf/open/floor/plating,
+/area/station/security/execution/transfer)
 "ghy" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -32996,11 +33550,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "gjD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white/end,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "gkj" = (
 /obj/structure/disposalpipe/segment,
@@ -33159,6 +33719,14 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/gravity_generator)
+"gnJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/kirbyplants/synthetic/plant29,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "gob" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 10
@@ -33174,6 +33742,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/gateway)
+"gon" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "gou" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -33186,24 +33761,36 @@
 /area/station/command/gateway)
 "goB" = (
 /obj/machinery/camera/directional/north,
-/turf/open/floor/plastic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "goT" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Court";
+	req_access = list("brig");
+	dir = 2
+	},
+/obj/structure/table/wood/fancy/blue{
+	dir = s
+	},
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/gavelhammer,
+/obj/machinery/digital_clock{
+	pixel_y = -10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/station/security/courtroom)
+"goX" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/hallway/secondary/service)
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "goZ" = (
 /obj/structure/table,
 /obj/item/watertank,
@@ -33232,6 +33819,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
+"gpt" = (
+/obj/structure/chair/pew{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	icon_state = "wood_parquet"
+	},
+/area/station/maintenance/port/fore)
 "gqa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
@@ -33312,10 +33907,11 @@
 /turf/closed/wall,
 /area/station/maintenance/aft)
 "gsX" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_half_contrasted";
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "gtt" = (
@@ -33345,13 +33941,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
+/turf/closed/wall/r_wall,
+/area/station/security/brig)
+"gui" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/commons/fitness)
+/obj/item/kirbyplants/synthetic/plant28,
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "guz" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet,
@@ -33400,10 +33998,22 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "gwP" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/obj/item/tape,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"gxj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "gxC" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
@@ -33500,14 +34110,23 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/garden)
 "gBW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/structure/rack/shelf,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "gCx" = (
 /obj/machinery/air_sensor/nitrogen_tank,
@@ -33520,8 +34139,9 @@
 "gDf" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/hats/tophat,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "gDD" = (
 /obj/structure/railing/corner/end/flip{
@@ -33587,7 +34207,17 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#5d341f";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/station/commons/dorms)
 "gES" = (
 /obj/effect/turf_decal/tile/purple{
@@ -33637,13 +34267,15 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation)
 "gFP" = (
-/obj/structure/hedge,
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/white{
+/obj/structure/chair/sofa/right{
+	color = "#8a3033"
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/grass,
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "gFS" = (
 /obj/effect/turf_decal/tile/blue{
@@ -33701,15 +34333,29 @@
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "gHk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 2
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
-/turf/open/floor/plastic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"gHt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 2
+	},
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "gIk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33802,10 +34448,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "gJP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/item/keycard/library,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "gKq" = (
@@ -33834,14 +34478,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gKP" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/structure/window/spawner/directional/west,
-/obj/item/reagent_containers/cup/rag,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/structure/flora/rock/pile/jungle/style_random{
+	pixel_y = 7
 	},
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/grass,
 /area/station/service/bar)
 "gLq" = (
 /obj/structure/chair{
@@ -33915,6 +34557,17 @@
 /obj/machinery/dish_drive/bullet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"gOB" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/table/reinforced,
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "gOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33931,6 +34584,9 @@
 "gOV" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "gPw" = (
@@ -33962,7 +34618,7 @@
 /area/station/service/chapel)
 "gQz" = (
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "gQO" = (
 /obj/effect/turf_decal/tile/red{
@@ -34035,6 +34691,26 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/brig)
+"gSm" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/machinery/light/directional/south{
+	dir = 1
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "gSC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -34184,6 +34860,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"gXT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitory"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/commons/dorms)
 "gYm" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -34260,7 +34947,9 @@
 "gZW" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "hab" = (
 /obj/machinery/computer/crew{
@@ -34356,18 +35045,19 @@
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_cafeteria)
 "hdP" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_half"
+	},
 /area/station/maintenance/fore/lesser)
 "hdS" = (
 /obj/structure/chair/comfy/brown{
@@ -34396,7 +35086,7 @@
 	location = "Security"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/area/station/security/brig)
 "hep" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -34483,14 +35173,22 @@
 /turf/open/floor/plating,
 /area/station/command/gateway)
 "hfM" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/storage/box/donkpockets{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/turf/open/floor/iron,
-/area/station/security/mechbay)
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "hgn" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -34517,14 +35215,28 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
 "hgK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table,
+/obj/item/storage/medkit,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/training_machine,
-/obj/item/target,
-/turf/open/floor/iron,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
+"hhb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "hhp" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "Library Desk Door";
@@ -34555,7 +35267,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "hiw" = (
 /obj/docking_port/stationary/escape_pod{
@@ -34727,8 +35441,14 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "hmT" = (
-/obj/machinery/vending/clothing,
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/vending/games,
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/railing{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/dorms)
 "hno" = (
@@ -34740,17 +35460,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "hns" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/station/commons/fitness)
 "hnt" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -34855,8 +35571,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "hre" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -34909,7 +35626,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/iron/white/small{
+	icon_state = "textured_white_large"
+	},
 /area/station/commons/toilet)
 "htF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34976,33 +35695,52 @@
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_cafeteria)
 "hwi" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 4
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron,
-/area/station/security/mechbay)
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 2
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "hwz" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
 "hwE" = (
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/machinery/door/airlock/bathroom{
+	name = "Cabin 2"
+	},
+/obj/machinery/light/small/directional/west{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "hxq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4;
+	color = "#9FED58"
+	},
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "hxs" = (
 /obj/structure/disposalpipe/segment{
@@ -35201,25 +35939,34 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/prison/safe)
-"hCl" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/commons/fitness)
-"hCy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
+"hBQ" = (
+/obj/machinery/door/airlock/security{
+	name = "Court maintenance"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 10
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
+"hCl" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark/side{
-	dir = 1
+/obj/effect/turf_decal/siding/white/end,
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
+"hCy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/area/station/commons/dorms)
+/obj/item/kirbyplants/synthetic/plant29,
+/turf/open/floor/carpet/red,
+/area/station/security/courtroom)
 "hCG" = (
 /turf/open/floor/iron,
 /area/station/science/ordnance/bomb)
@@ -35284,12 +36031,14 @@
 /area/station/security/prison/work)
 "hEb" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "hEJ" = (
 /obj/effect/turf_decal/bot,
@@ -35303,11 +36052,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "hFi" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "hFm" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -35448,8 +36194,9 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "hKj" = (
-/obj/effect/landmark/start/bartender,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "hKm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -35458,11 +36205,8 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "hKq" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/fore/lesser)
 "hKu" = (
 /obj/machinery/modular_computer/preset/civilian,
@@ -35668,24 +36412,27 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "hQC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/training_toolbox{
-	pixel_y = 5
+/obj/effect/turf_decal/siding/white{
+	dir = 5
 	},
-/obj/structure/table,
-/obj/item/training_toolbox{
-	pixel_y = -2
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "hQT" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 8
+	},
+/turf/open/floor/iron/stairs/old{
+	color = "#784936"
+	},
 /area/station/service/bar)
 "hQX" = (
 /obj/machinery/light/directional/north,
@@ -35712,10 +36459,16 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/structure/chair/comfy/black{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/hedge,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 6
+	},
+/turf/open/floor/grass,
 /area/station/service/bar)
 "hRy" = (
 /obj/structure/cable,
@@ -35779,14 +36532,16 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "hTl" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/chem_dispenser/drinks/beer,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "hTu" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -35848,6 +36603,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"hWz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/commons/dorms)
 "hWN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -35873,18 +36639,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "hYp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/commons/dorms)
+/obj/structure/table/wood,
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "hYR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35944,6 +36704,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/breakroom)
+"iaQ" = (
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
+/area/station/commons/toilet)
 "iaU" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar/directional/north,
@@ -35969,6 +36737,10 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation)
+"icj" = (
+/obj/effect/decal/cleanable/garbage,
+/turf/closed/wall,
+/area/station/maintenance/port/fore)
 "icm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/holopad,
@@ -35985,6 +36757,12 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/closed/wall/r_wall,
 /area/station/security/execution)
+"icT" = (
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/random/entertainment/deck,
+/obj/item/flashlight/flare/candle/vanilla,
+/turf/open/floor/carpet/red,
+/area/station/service/bar)
 "icV" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -36137,8 +36915,19 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "ihj" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "ihv" = (
 /obj/structure/chair/sofa/bench/tram/corner{
@@ -36157,13 +36946,19 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "ihE" = (
-/obj/machinery/light/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "ihX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance)
+"iie" = (
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood_parquet"
+	},
+/area/station/maintenance/port/fore)
 "iiB" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -36213,12 +37008,32 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "ijM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/turf/open/floor/iron/white/herringbone,
-/area/station/service/bar)
+/obj/item/pen,
+/turf/open/floor/wood/large,
+/area/station/service/lawoffice)
+"ijT" = (
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 2
+	},
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 4
+	},
+/obj/structure/table/wood/fancy/blue{
+	dir = s
+	},
+/obj/item/table_clock{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/station/security/courtroom)
 "ijY" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -36308,9 +37123,12 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Bathroom"
 	},
-/obj/structure/urinal/directional/north,
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "imk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -36404,10 +37222,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "iqj" = (
-/obj/structure/table/wood,
-/obj/item/storage/briefcase,
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood/tile,
+/obj/item/storage/briefcase{
+	pixel_y = 7
+	},
+/obj/item/storage/briefcase,
+/obj/item/storage/briefcase{
+	pixel_y = -6
+	},
+/obj/structure/closet/secure_closet/personal/cabinet{
+	name = "Law closet"
+	},
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "iqK" = (
 /obj/effect/turf_decal/tile/red{
@@ -36515,6 +37341,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"iuN" = (
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/hedge,
+/turf/open/floor/grass,
+/area/station/service/bar)
 "ivv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36716,12 +37554,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "iCj" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white/herringbone,
+/obj/machinery/reagentgrinder,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/reagent_containers/cup/glass/shaker,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "iCl" = (
 /obj/structure/disposalpipe/segment{
@@ -36762,10 +37601,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/chair/comfy/black{
-	dir = 8
+/turf/open/floor/wood/large{
+	icon_state = "wood_tile"
 	},
-/turf/open/floor/iron/white/herringbone,
 /area/station/service/bar)
 "iCO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36796,6 +37634,21 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"iEe" = (
+/mob/living/basic/cockroach,
+/obj/item/kitchen/fork{
+	pixel_x = -9
+	},
+/obj/item/flashlight/flare/candle{
+	pixel_x = 5;
+	pixel_y = 45
+	},
+/obj/item/trash/candle{
+	pixel_x = 6;
+	pixel_y = 45
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "iEp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -36922,8 +37775,9 @@
 /area/station/hallway/secondary/exit)
 "iHT" = (
 /obj/machinery/biogenerator,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/hydroponics/garden)
 "iIQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -36954,11 +37808,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iJl" = (
-/obj/structure/chair/sofa/corp/right,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/comfy{
+	color = "#8a3033";
+	dir = 4
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
+"iJt" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "iJU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -37087,6 +37956,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"iPm" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "iPn" = (
 /obj/machinery/door/poddoor/shutters/window{
 	id = "armory";
@@ -37105,6 +37990,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"iPz" = (
+/obj/effect/decal/cleanable/garbage{
+	pixel_x = 22;
+	pixel_y = 12
+	},
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood{
+	icon_state = "wood_large"
+	},
+/area/station/maintenance/port/fore)
 "iPE" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -37272,8 +38170,12 @@
 /area/station/security/office)
 "iWe" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -37285,28 +38187,27 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/breakroom)
 "iWV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_corner";
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
+/obj/machinery/door/window/left/directional/west{
+	name = "Fitness Ring";
 	dir = 1
 	},
-/area/station/commons/dorms)
-"iXa" = (
-/obj/structure/hedge,
 /obj/structure/railing{
-	dir = 10
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/white/end{
-	dir = 8
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
+"iXa" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large{
+	icon_state = "wood_parquet"
 	},
-/turf/open/floor/grass,
 /area/station/service/bar)
 "iXm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -37411,11 +38312,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jbp" = (
-/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/closed/wall,
 /area/station/commons/toilet)
 "jbq" = (
 /obj/structure/kitchenspike,
@@ -37506,7 +38406,14 @@
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
 "jeE" = (
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/spawner/xmastree,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/stairs/old{
+	color = "#784936";
+	dir = 8
+	},
 /area/station/service/bar)
 "jeI" = (
 /obj/structure/closet,
@@ -37694,6 +38601,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"jkm" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/red,
+/area/station/service/bar)
 "jkM" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/siding/purple{
@@ -37777,7 +38689,10 @@
 "jms" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "jmw" = (
 /obj/structure/cable,
@@ -38011,9 +38926,31 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "jtf" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/machinery/coffeemaker{
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/cup/coffeepot{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 8
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "jtt" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38139,7 +39076,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/hedge,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/station/service/bar)
 "jyk" = (
 /obj/machinery/door/airlock/maintenance,
@@ -38157,6 +39106,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
+"jyz" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/stairs/old{
+	color = "#b0b0b0"
+	},
+/area/station/commons/fitness)
 "jyS" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/west,
@@ -38232,6 +39189,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"jAi" = (
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/white/small,
+/area/station/commons/toilet)
 "jAj" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -38428,9 +39389,19 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "jGC" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/item/storage/medkit/brute,
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "jHt" = (
 /obj/structure/disposalpipe/segment{
@@ -38670,6 +39641,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
+"jPO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/station/commons/toilet)
 "jPU" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
@@ -38945,14 +39930,14 @@
 	},
 /area/station/hallway/secondary/exit)
 "jXl" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "jXq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -39059,6 +40044,20 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/security/prison)
+"kat" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/table/glass,
+/obj/item/food/grown/cocoapod,
+/obj/item/food/grown/grapes,
+/obj/item/food/grown/citrus/orange,
+/obj/item/food/grown/watermelon,
+/obj/item/food/grown/watermelon,
+/obj/item/food/grown/watermelon,
+/obj/item/food/grown/wheat,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
+/area/station/service/hydroponics/garden)
 "kaE" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/red,
@@ -39090,9 +40089,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kce" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/wood/tile,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "kcw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -39317,6 +40314,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"kjJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/item/kirbyplants/synthetic/plant27,
+/turf/open/floor/carpet/red,
+/area/station/security/courtroom)
 "kkH" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/checker,
@@ -39390,14 +40394,16 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "knr" = (
-/obj/structure/table,
-/obj/effect/spawner/random/engineering/tool{
-	pixel_y = 6;
-	pixel_x = 1
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
 	},
-/obj/item/poster/random_official,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/structure/chair/sofa/left{
+	color = "#596479"
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "knw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -39430,12 +40436,12 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/hos)
 "koe" = (
-/obj/structure/sink/directional/south,
-/obj/machinery/camera/directional/east{
-	c_tag = "Garden North"
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood{
+	icon_state = "wood_tile"
 	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics/garden)
+/area/station/maintenance/port/fore)
 "koC" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -39451,13 +40457,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kpg" = (
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle"
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "kph" = (
@@ -39925,9 +40932,11 @@
 /area/station/ai_monitored/command/nuke_storage)
 "kCD" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/turf_decal/stripes/white/line,
 /obj/machinery/modular_computer/preset/cargochat/service,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 6
+	},
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "kCY" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -39970,15 +40979,15 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/aft)
 "kDk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plastic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "kDo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40115,6 +41124,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
+"kGL" = (
+/obj/machinery/hydroponics/soil,
+/obj/structure/flora/bush/jungle/b/style_random{
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "kGQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40292,9 +41309,11 @@
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "kNq" = (
-/obj/effect/turf_decal/trimline/green/line,
 /obj/item/kirbyplants/random/fullysynthetic,
-/turf/open/floor/plastic,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "kNT" = (
 /obj/structure/table/wood,
@@ -40340,10 +41359,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms)
 "kPd" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 4
+/obj/structure/table,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
 	},
-/turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/service)
 "kPj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -40408,7 +41427,6 @@
 	pixel_y = 28;
 	pixel_x = -7
 	},
-/obj/machinery/vending/boozeomat,
 /obj/machinery/button/door{
 	id = "barShutters";
 	name = "Bar Shutters";
@@ -40418,7 +41436,14 @@
 /obj/machinery/requests_console/directional/west,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/ore_update,
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/wideplating/dark/end,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "kRc" = (
 /obj/machinery/airalarm/directional/north,
@@ -40439,7 +41464,11 @@
 /area/station/medical/medbay/aft)
 "kRB" = (
 /obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/wood,
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "kRC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40498,17 +41527,15 @@
 /area/station/command/heads_quarters/hos)
 "kUu" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/turf/closed/wall/r_wall,
+/area/station/security/brig)
 "kUA" = (
-/obj/structure/chair/comfy/black{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "kUI" = (
 /obj/machinery/flasher{
@@ -40568,9 +41595,10 @@
 /area/station/commons/dorms)
 "kWH" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+	dir = 8;
+	color = "#9FED58"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "kWJ" = (
 /obj/structure/sign/warning/secure_area/directional/west,
@@ -40595,22 +41623,31 @@
 	dir = 9
 	},
 /area/station/science/research)
-"kYn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"kYe" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large{
+	icon_state = "wood_parquet"
 	},
+/area/station/service/bar)
+"kYn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/airlock/service{
 	name = "Bar Service Hall"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/bar,
-/turf/open/floor/plastic,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "kYu" = (
 /obj/structure/table,
@@ -40649,7 +41686,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/wood/tile,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "kYN" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -40758,10 +41796,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "lew" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "leH" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -40800,12 +41842,12 @@
 /area/station/service/library)
 "lfY" = (
 /obj/structure/cable,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 9
 	},
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "lgc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -40851,10 +41893,23 @@
 "lhD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 8
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 4
+	},
+/turf/open/floor/iron/stairs/old{
+	color = "#784936"
+	},
+/area/station/service/bar)
 "lhR" = (
 /obj/machinery/camera/directional/south,
 /turf/open/floor/iron/dark,
@@ -40870,23 +41925,22 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "liv" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "liz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/machinery/door/airlock/security{
+	name = "Court maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "liE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40903,7 +41957,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/sofa/right{
+	color = "#8a3033";
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "liZ" = (
 /obj/machinery/airalarm/directional/east,
@@ -40972,20 +42030,26 @@
 /turf/closed/wall,
 /area/station/maintenance/port)
 "lmD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner/end/flip{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_half_contrasted";
+	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
-"lmF" = (
-/obj/structure/hedge,
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 2
+	},
 /obj/structure/railing,
-/obj/effect/turf_decal/siding/white/end{
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
+"lmF" = (
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
 	dir = 8
 	},
-/turf/open/floor/grass,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "lmI" = (
 /obj/effect/turf_decal/siding/wood{
@@ -41002,9 +42066,18 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "lnJ" = (
-/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 2
+	},
 /obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#9FED58"
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 4
+	},
 /area/station/hallway/secondary/service)
 "log" = (
 /obj/structure/cable,
@@ -41045,8 +42118,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
 "lrc" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "lre" = (
 /obj/machinery/iv_drip,
@@ -41056,7 +42134,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
 "lrf" = (
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/security{
 	name = "Law Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
@@ -41127,13 +42205,14 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "luk" = (
-/obj/item/reagent_containers/cup/glass/shaker,
+/obj/structure/closet/secure_closet/bar,
+/obj/item/holosign_creator/robot_seat/bar,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
-/obj/structure/table/wood,
-/obj/item/stack/spacecash/c10,
 /obj/item/stack/spacecash/c100,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/wood,
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "lul" = (
 /obj/machinery/camera/directional/west,
@@ -41149,10 +42228,16 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "luG" = (
-/obj/structure/chair{
-	name = "Judge"
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Judge";
+	dir = 8;
+	req_access = list("brig")
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "luH" = (
 /obj/structure/sign/warning/secure_area/directional/west,
@@ -41190,7 +42275,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/corner,
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "lwp" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -41204,9 +42289,20 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit)
+"lwv" = (
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
+	},
+/obj/structure/flora/ocean/longseaweed,
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "lwz" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/white/herringbone,
+/obj/machinery/smartfridge/drinks,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "lwA" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -41379,11 +42475,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "lBo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
@@ -41427,6 +42523,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden/abandoned)
+"lCO" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "lCT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -41462,7 +42562,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "lEE" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -41486,9 +42591,8 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
 "lFf" = (
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
+/obj/effect/landmark/start/clown,
+/turf/open/floor/carpet/blue,
 /area/station/service/theater)
 "lFl" = (
 /obj/machinery/computer/records/security,
@@ -41562,7 +42666,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "lHs" = (
 /turf/closed/wall,
@@ -41591,10 +42695,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/prison/workout)
 "lIJ" = (
-/obj/machinery/door/airlock{
-	name = "Showers"
+/obj/machinery/door/airlock/shuttle{
+	name = "Shower"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/white/small{
+	icon_state = "textured_white_large"
+	},
 /area/station/commons/toilet)
 "lIK" = (
 /obj/structure/chair/wood,
@@ -41760,6 +42866,9 @@
 "lLO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
@@ -41991,9 +43100,17 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "lTG" = (
-/obj/structure/window/spawner/directional/west,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 8
+	},
+/area/station/service/bar)
 "lTQ" = (
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
@@ -42012,14 +43129,11 @@
 /turf/open/floor/plating,
 /area/station/medical/break_room)
 "lUg" = (
-/obj/structure/table/wood,
-/obj/machinery/fax{
-	fax_name = "Law Office";
-	name = "Law Office Fax Machine"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "lUy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -42049,15 +43163,17 @@
 "lVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/siding/white/end,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark/side{
-	dir = 1
+/obj/structure/closet/boxinggloves,
+/obj/structure/railing{
+	dir = 5
 	},
-/area/station/commons/dorms)
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "lVy" = (
 /obj/structure/chair/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -42071,12 +43187,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/south,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 1
-	},
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/side,
 /area/station/commons/dorms)
 "lVV" = (
@@ -42143,6 +43253,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
+"lXl" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/hydroponics/soil,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "lXE" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
 	dir = 8
@@ -42228,11 +43346,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "mbo" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
+/obj/machinery/camera/directional/east{
+	c_tag = "Garden North"
 	},
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "mbz" = (
@@ -42250,11 +43368,22 @@
 /turf/open/floor/iron,
 /area/station/science/explab)
 "mcS" = (
-/obj/structure/chair/sofa/corp{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "mdb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42401,11 +43530,10 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance)
 "mhT" = (
-/obj/effect/landmark/event_spawn,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "mhU" = (
 /obj/effect/turf_decal/tile/brown,
@@ -42439,16 +43567,37 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "miW" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -5;
+	pixel_y = 30
 	},
-/turf/open/floor/iron,
+/obj/structure/table/glass,
+/obj/item/plant_analyzer,
+/obj/item/crowbar,
+/obj/item/hatchet,
+/obj/item/cultivator,
+/obj/machinery/light/directional/east{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/hydroponics/garden)
 "miY" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/left/directional/south{
-	name = "Court Cell";
-	req_access = list("brig")
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/window/reinforced/spawner/directional/south{
+	pixel_y = -4
+	},
+/obj/structure/window/reinforced/spawner/directional/south{
+	pixel_y = -4;
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
@@ -42477,8 +43626,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mjr" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood,
+/obj/structure/closet,
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "mkt" = (
 /obj/structure/bookcase/random/reference,
@@ -42575,13 +43729,23 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "mqD" = (
+/obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/white/end{
 	dir = 1
 	},
-/obj/effect/spawner/random/entertainment/arcade{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "mqS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -42770,7 +43934,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "myW" = (
-/turf/open/floor/plastic,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "mzk" = (
 /obj/machinery/flasher{
@@ -42794,21 +43961,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "mzs" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light/directional/west{
+	dir = 2
 	},
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "mzV" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/blue,
 /area/station/service/theater)
 "mAr" = (
 /obj/effect/turf_decal/tile/red{
@@ -42887,7 +44052,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/diagonal,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "mCG" = (
 /obj/effect/spawner/liquids_spawner{
@@ -42958,7 +44124,16 @@
 /area/station/science/breakroom)
 "mEU" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "mEX" = (
 /obj/effect/turf_decal/stripes/line{
@@ -43026,8 +44201,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "mHQ" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
+/obj/machinery/door/airlock/bathroom{
+	name = "Cabin 2"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -43036,7 +44211,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/toilet)
 "mHR" = (
 /obj/structure/disposalpipe/segment,
@@ -43250,6 +44425,9 @@
 "mPD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/structure/railing{
 	dir = 1
 	},
@@ -43277,19 +44455,30 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "mRd" = (
-/obj/structure/table/wood,
-/obj/item/pen/red,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/folder/blue,
-/obj/item/stamp/law,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/obj/structure/filingcabinet/employment{
+	pixel_x = 10
 	},
-/turf/open/floor/wood/tile,
+/obj/structure/filingcabinet/employment,
+/obj/structure/filingcabinet/employment{
+	pixel_x = -10
+	},
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
+"mRn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "mRr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43341,10 +44530,10 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "mSW" = (
-/obj/structure/railing/corner/end{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -43374,6 +44563,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/nuke_storage)
+"mUK" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore/lesser)
 "mUV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -43391,7 +44584,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/random/entertainment/lighter,
+/obj/machinery/light/directional/west{
+	dir = 2
+	},
+/obj/item/flashlight/flare/candle/vanilla,
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "mWm" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -43542,7 +44741,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_half"
+	},
 /area/station/maintenance/fore/lesser)
 "naY" = (
 /obj/effect/turf_decal/tile/blue{
@@ -43715,7 +44917,16 @@
 "nfa" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/white{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "nfb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43912,12 +45123,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "nny" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/area/station/commons/fitness)
 "nnI" = (
 /obj/structure/table,
 /obj/structure/microscope,
@@ -43925,13 +45138,21 @@
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "nnO" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
 	},
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/west,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/comfy{
+	color = "#8a3033";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 8
+	},
+/area/station/service/bar)
 "noK" = (
 /obj/structure/girder,
 /turf/open/floor/iron/dark,
@@ -43960,6 +45181,14 @@
 /obj/machinery/air_sensor/nitrous_tank,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"nqP" = (
+/obj/machinery/shower/directional/east,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
+/area/station/commons/toilet)
 "nrc" = (
 /obj/structure/chair/comfy{
 	color = "#596479";
@@ -44175,13 +45404,24 @@
 	},
 /area/station/security/prison/work)
 "nxn" = (
-/obj/structure/chair/stool/bar/directional/east{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/comfy{
+	color = "#8a3033";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "nxx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -44220,6 +45460,14 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
+"nyd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "nyk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -44321,14 +45569,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nCi" = (
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/cable_coil,
+/obj/structure/cable,
+/obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/flashlight/lamp,
 /obj/item/flashlight/lamp/green,
-/obj/structure/table/wood,
-/obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "nCm" = (
 /obj/structure/cable,
@@ -44340,7 +45587,14 @@
 	},
 /obj/structure/disposalpipe/sorting/mail,
 /obj/effect/mapping_helpers/mail_sorting/service/law_office,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "nCu" = (
 /obj/structure/disposalpipe/segment{
@@ -44362,9 +45616,19 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/aft)
 "nCw" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/spawner/random/entertainment/lighter,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/table/wood/fancy,
+/obj/structure/table/wood/fancy,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 10
+	},
+/obj/item/flashlight/flare/candle/vanilla{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/obj/effect/spawner/random/entertainment/cigarette,
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "nCL" = (
 /obj/machinery/light/directional/east,
@@ -44454,12 +45718,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"nEz" = (
+/obj/effect/landmark/start/bouncer,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/large{
+	icon_state = "wood_tile"
+	},
+/area/station/service/bar)
 "nEJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
-/turf/open/floor/wood/tile,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Law Office"
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "nEN" = (
 /obj/structure/disposalpipe/segment,
@@ -44555,13 +45834,17 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "nFJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/turf/open/floor/iron/dark/side{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "nFQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -44867,9 +46150,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "nQe" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/anticorner,
-/turf/open/floor/iron/dark,
+/obj/structure/table/wood/fancy/blue{
+	dir = s
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "nQl" = (
 /obj/structure/cable,
@@ -44982,16 +46269,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "nRJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /obj/effect/landmark/navigate_destination,
 /obj/machinery/door/airlock/service{
-	name = "Bar Storage"
+	name = "Bar Entrance"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/service/bar)
 "nSq" = (
@@ -45017,6 +46302,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"nSR" = (
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/folder/blue,
+/obj/item/pen/red,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/large,
+/area/station/service/lawoffice)
 "nTh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -45089,6 +46385,15 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"nVQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty{
+	pixel_x = 12;
+	pixel_y = 17
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "nWd" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
@@ -45120,9 +46425,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "nWZ" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/coin,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "nXi" = (
 /obj/effect/turf_decal/tile/purple,
@@ -45152,13 +46464,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "nXO" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/mech_bay_recharge_port{
 	dir = 1
 	},
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
-/obj/machinery/camera/directional/west,
 /turf/open/floor/iron,
 /area/station/security/mechbay)
 "nXR" = (
@@ -45225,6 +46533,14 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation)
+"nYI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/central)
 "nZA" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -45298,8 +46614,16 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/storage)
 "ocj" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/sofa/middle{
+	color = "#8a3033";
+	dir = 8
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "ocq" = (
 /obj/structure/cable,
@@ -45319,6 +46643,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
+"oeE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/security/mechbay)
 "oeI" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
@@ -45352,7 +46686,15 @@
 /turf/closed/wall,
 /area/station/science/ordnance/storage)
 "ogn" = (
-/obj/machinery/vending/cigarette,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/railing{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/dorms)
 "ogx" = (
@@ -45451,6 +46793,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"oiB" = (
+/obj/machinery/door/airlock/security{
+	name = "Court maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/fore/lesser)
 "oju" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -45501,8 +46858,13 @@
 	},
 /area/station/science/server)
 "omR" = (
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/wood/tile,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/machinery/computer/security/telescreen/prison,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "omS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -45571,6 +46933,11 @@
 /obj/effect/mapping_helpers/mail_sorting/science/genetics,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/genetics)
+"ooO" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "opE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -45589,26 +46956,30 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden/abandoned)
 "oqj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
 	},
-/obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "oqm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/railing/corner/end{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "oqt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -45644,17 +47015,18 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/command/gateway)
 "ore" = (
-/obj/machinery/door/airlock{
-	name = "Law Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/service/lawoffice)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "orw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45672,8 +47044,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "orE" = (
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 7
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "orS" = (
 /obj/structure/sign/barber{
@@ -45707,17 +47091,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "osW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_corner";
+	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/commons/dorms)
+/area/station/maintenance/fore/lesser)
 "oth" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Incoming Mail";
@@ -45746,6 +47125,19 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
+"otE" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_corner"
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "otF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45901,8 +47293,8 @@
 /area/station/hallway/secondary/entry)
 "owl" = (
 /obj/machinery/status_display/evac/directional/east,
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/noticeboard/directional,
+/turf/closed/wall,
 /area/station/service/bar)
 "owt" = (
 /obj/effect/turf_decal/siding/wood{
@@ -46032,12 +47424,10 @@
 /area/station/security/brig)
 "oAB" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/structure/hedge,
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/white/end{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/large{
+	icon_state = "wood_tile"
 	},
-/turf/open/floor/grass,
 /area/station/service/bar)
 "oAP" = (
 /obj/structure/cable,
@@ -46139,8 +47529,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oFL" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/wood/tile,
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "oFZ" = (
 /obj/structure/cable,
@@ -46178,20 +47572,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "oGT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/hedge,
-/obj/effect/turf_decal/siding/white/end{
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
-/turf/open/floor/grass,
+/obj/structure/chair/sofa/left{
+	color = "#8a3033";
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "oHk" = (
 /obj/effect/turf_decal/tile/blue{
@@ -46231,6 +47625,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/aft)
+"oJD" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "oJI" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
@@ -46278,8 +47678,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west,
+/obj/vehicle/sealed/mecha/ripley/paddy/preset,
+/turf/open/floor/iron/recharge_floor,
 /area/station/security/mechbay)
 "oLf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -46321,11 +47728,26 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "oMv" = (
-/obj/structure/chair{
-	name = "Judge"
-	},
 /obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark,
+/obj/structure/chair/comfy/brown{
+	dir = 2;
+	name = "Judge";
+	color = "#415b8c"
+	},
+/obj/item/clothing/suit/costume/judgerobe,
+/obj/item/clothing/head/costume/powdered_wig{
+	pixel_y = 11
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/light/directional/east{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "oMP" = (
 /obj/structure/table/wood,
@@ -46357,15 +47779,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
 "oNi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/commons/dorms)
+/obj/item/kirbyplants/synthetic/plant28,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "oNl" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -46399,13 +47815,13 @@
 /area/station/medical/medbay/aft)
 "oNK" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/mapping_helpers/airlock/access/any/service/theatre,
-/obj/effect/landmark/navigate_destination,
-/obj/machinery/door/airlock/service{
-	name = "Theatre"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/turf/open/floor/wood/large{
+	icon_state = "wood_parquet"
+	},
+/area/station/service/bar)
 "oOF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46413,41 +47829,54 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "oOI" = (
-/obj/structure/table,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/tool{
-	pixel_x = 16;
-	pixel_y = -3
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/structure/chair/sofa/right{
+	color = "#596479"
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "oOL" = (
 /obj/machinery/firealarm/directional/east,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/directional/east{
 	c_tag = "Bar"
 	},
-/obj/structure/table/wood,
-/obj/item/instrument/violin,
-/obj/item/instrument/eguitar{
-	pixel_x = 5
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
 	},
-/obj/item/instrument/guitar{
-	pixel_x = -7
-	},
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/obj/structure/flora/rock/pile/jungle/style_random,
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "oOU" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock)
+"oPM" = (
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 5
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784938";
+	dir = 1
+	},
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
+/area/station/service/bar)
 "oPX" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/landmark/start/lawyer,
-/turf/open/floor/wood/tile,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "oQe" = (
 /obj/structure/chair/office/light{
@@ -46617,6 +48046,21 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/service/hydroponics)
+"oWE" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/machinery/door/airlock/bathroom{
+	name = "Cabin 1"
+	},
+/obj/machinery/light/small/directional/west{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white/end{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/station/commons/toilet)
 "oWR" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "Monkey Pen";
@@ -46780,11 +48224,12 @@
 /obj/structure/sign/picture_frame/portrait/bar{
 	pixel_x = -32
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/vending/boozeomat,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/dark/diagonal,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "pby" = (
 /obj/structure/disposalpipe/segment{
@@ -46819,30 +48264,31 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "pdv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/wood/large{
+	icon_state = "wood_parquet"
+	},
 /area/station/service/bar)
 "pdD" = (
-/obj/structure/railing/corner/end{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron,
 /area/station/commons/fitness)
 "pdQ" = (
-/obj/structure/flora/ocean/seaweed,
-/obj/structure/flora/bush/sparsegrass,
-/obj/structure/flora/bush/grassy,
-/obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
 	},
-/mob/living/basic/carp/passive,
-/obj/structure/window/spawner/directional/south,
-/turf/open/water/overlay,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/comfy{
+	color = "#8a3033";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 4
+	},
 /area/station/service/bar)
 "pdW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46890,10 +48336,23 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "peW" = (
-/obj/machinery/door/window/right/directional/west,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/restaurant_portal/bar,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 9
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 8
+	},
+/area/station/service/bar)
 "pfa" = (
 /obj/machinery/requests_console{
 	department = "Medbay";
@@ -46975,6 +48434,18 @@
 /obj/machinery/camera/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
+"pgT" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/hallway/primary/central)
 "phd" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
@@ -47044,6 +48515,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "piX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -47198,8 +48675,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "ppW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -47220,13 +48699,28 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
-"pqO" = (
-/obj/structure/disposalpipe/segment,
+"pqE" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/commons/dorms)
+"pqO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/wood/large{
+	icon_state = "wood_parquet"
+	},
 /area/station/service/bar)
 "pqV" = (
 /obj/structure/table/wood,
@@ -47244,6 +48738,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"psd" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "psi" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals Lounge"
@@ -47337,18 +48835,36 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pvi" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "pvj" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/deck,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/white/end,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "pvk" = (
 /obj/structure/disposalpipe/segment,
@@ -47396,27 +48912,39 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pxf" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "pxu" = (
-/obj/structure/railing{
-	dir = 5
+/obj/structure/railing/corner/end{
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
+/obj/structure/railing/corner/end/flip,
 /turf/open/floor/iron,
 /area/station/security/mechbay)
 "pxB" = (
-/obj/structure/chair/sofa/corp{
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/siding/white/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "pxV" = (
 /obj/structure/cable,
@@ -47562,21 +49090,26 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/genetics)
 "pCQ" = (
-/obj/machinery/light/directional/west,
-/obj/structure/bed{
-	dir = 4
+/obj/item/reagent_containers/cup/bucket{
+	pixel_y = 6;
+	pixel_x = 12
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "pCU" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "pDY" = (
 /obj/structure/disposalpipe/segment{
@@ -47601,6 +49134,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"pEt" = (
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark,
+/area/station/service/lawoffice)
 "pEK" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -47647,9 +49185,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "pGo" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/spawner/directional/south{
+	pixel_y = -4
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "pGD" = (
 /obj/structure/cable,
@@ -47741,17 +49282,18 @@
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "pJI" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/hydroponics)
 "pJL" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
+/obj/structure/chair/sofa/left{
+	color = "#8a3033";
+	dir = 8
 	},
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "pKi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47812,9 +49354,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "pMl" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "pMv" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/science,
@@ -47852,18 +49396,13 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "pOR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/hallway/secondary/service)
+/area/station/security/brig)
 "pOU" = (
 /obj/machinery/button/door/directional/west{
 	id = "commissarydoor";
@@ -47943,6 +49482,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"pQq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "pQw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing/corner{
@@ -48023,11 +49570,20 @@
 /area/station/hallway/secondary/exit)
 "pUe" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#9FED58"
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 4
+	},
 /area/station/hallway/secondary/service)
 "pUi" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -48095,6 +49651,17 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
+"pXQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "pYd" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/blueshield,
@@ -48118,8 +49685,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "pZN" = (
@@ -48250,16 +49816,12 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "qeP" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/blue,
 /area/station/service/theater)
 "qff" = (
 /turf/open/floor/iron/dark/small,
@@ -48353,10 +49915,18 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "qhE" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 1
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "qhN" = (
 /obj/structure/cable,
@@ -48438,9 +50008,10 @@
 /area/station/science/explab)
 "qkI" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+	dir = 4;
+	color = "#9FED58"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "qkP" = (
 /obj/structure/table,
@@ -48568,6 +50139,10 @@
 "qpi" = (
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
+"qpq" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "qps" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -48579,8 +50154,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "qpx" = (
 /obj/effect/turf_decal/tile/blue{
@@ -48661,6 +50240,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
+"qrz" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/stairs/old{
+	color = "#b0b0b0";
+	dir = 1
+	},
+/area/station/commons/fitness)
 "qrK" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -48725,13 +50313,19 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "qsM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/structure/chair/pew/left{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 2
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "qsP" = (
 /obj/structure/bed{
 	dir = 4
@@ -48766,15 +50360,11 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/abandoned)
 "qtR" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575"
 	},
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "qtX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -48858,13 +50448,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "qwT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/south{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/obj/structure/rack/shelf,
+/obj/item/reagent_containers/condiment/protein,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "qwZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -48875,6 +50482,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
+"qxK" = (
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	color = "#777575";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "qxR" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Room"
@@ -48892,6 +50506,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"qzn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/lawoffice)
 "qzF" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Bitrunners Den"
@@ -48909,8 +50529,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "qzO" = (
-/turf/open/floor/iron/showroomfloor,
-/area/station/hallway/secondary/service)
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "qzX" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -48935,6 +50556,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/tile,
 /area/station/common/pool)
+"qAW" = (
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "qBb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -49050,11 +50678,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "qEl" = (
-/obj/structure/chair/stool/bar/directional/east{
-	dir = 2
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "qEJ" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
@@ -49102,6 +50731,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
+"qGo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "qGG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49331,9 +50969,13 @@
 /area/station/engineering/atmos)
 "qNT" = (
 /obj/structure/railing{
-	dir = 5
+	name = "wooden railing";
+	color = "#784938";
+	dir = 1
 	},
-/turf/open/floor/glass,
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/grass,
 /area/station/service/bar)
 "qNU" = (
 /obj/machinery/oven,
@@ -49423,11 +51065,16 @@
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "qRG" = (
-/obj/structure/railing{
-	dir = 4
+/turf/open/floor/iron/stairs/old{
+	color = "#784936"
 	},
-/turf/open/floor/iron/white/herringbone,
 /area/station/service/bar)
+"qRO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "qSu" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
@@ -49655,9 +51302,9 @@
 	},
 /area/station/science/research)
 "qXA" = (
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/effect/spawner/random/entertainment/plushie,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "qXD" = (
 /turf/closed/wall,
 /area/station/maintenance/central/lesser)
@@ -49797,7 +51444,20 @@
 /area/station/science/ordnance)
 "rcV" = (
 /obj/structure/closet/secure_closet/personal,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "rda" = (
 /turf/closed/wall/r_wall,
@@ -49825,6 +51485,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "rdI" = (
@@ -49926,6 +51587,14 @@
 "rhJ" = (
 /turf/closed/wall,
 /area/station/security/interrogation)
+"rhN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large{
+	icon_state = "wood_parquet"
+	},
+/area/station/service/bar)
 "rhV" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -49950,12 +51619,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rij" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/courtroom)
+/obj/item/kirbyplants/synthetic/plant29,
+/turf/open/floor/carpet/red,
+/area/station/service/bar)
 "rjd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -50062,7 +51728,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/genetics)
 "roq" = (
-/obj/machinery/vending/autodrobe,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 2
+	},
+/obj/structure/railing{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/commons/dorms)
 "roJ" = (
@@ -50071,6 +51745,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"roQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/stairs/old{
+	color = "#784936"
+	},
+/area/station/service/bar)
 "roW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -50081,12 +51763,19 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "rpf" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/red,
 /area/station/security/courtroom)
+"rpn" = (
+/obj/structure/bed/maint,
+/turf/open/floor/iron/dark,
+/area/station/security/execution/transfer)
 "rps" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -50154,9 +51843,21 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "rrb" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp{
+	pixel_y = 15;
+	pixel_x = -5
+	},
+/obj/item/paper{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
 /area/station/maintenance/fore/lesser)
 "rrc" = (
 /obj/structure/disposalpipe/segment,
@@ -50168,7 +51869,7 @@
 /area/station/hallway/primary/central)
 "rrd" = (
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "rrm" = (
 /obj/effect/landmark/event_spawn,
@@ -50219,9 +51920,16 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "rst" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/commons/fitness)
 "rta" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -50292,25 +52000,31 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "rwN" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "rxc" = (
-/obj/structure/hedge,
-/obj/structure/railing,
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
-/turf/open/floor/grass,
+/turf/open/floor/wood/large{
+	icon_state = "wood_parquet"
+	},
 /area/station/service/bar)
 "rxk" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
+"ryq" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "ryu" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
@@ -50327,6 +52041,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/prison/safe)
+"rzf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "rzl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -50432,10 +52162,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/south,
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/spawner/random/entertainment/deck,
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/kirbyplants/synthetic/plant27,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "rCl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -50463,8 +52194,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/hedge,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/grass,
 /area/station/service/bar)
 "rDA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50496,12 +52238,19 @@
 /area/station/service/hydroponics)
 "rEY" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/displaycase/forsale/kitchen{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "rFq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/tile,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "rFu" = (
 /obj/structure/cable,
@@ -50668,6 +52417,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/construction)
+"rKT" = (
+/obj/structure/cable,
+/obj/machinery/door/puzzle/keycard/library,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "rKU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
@@ -50680,6 +52435,17 @@
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"rLb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/item/banner/medical/mundane{
+	icon_state = "banner-green";
+	warcry = "Невиновен, оправдан.";
+	name = "Defence Banner"
+	},
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "rLn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -50688,14 +52454,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "rLs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/bar)
@@ -50852,8 +52617,14 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "rSM" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/sofa/left{
+	color = "#8a3033";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "rST" = (
 /obj/structure/table,
@@ -50905,19 +52676,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "rVc" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "Toilet2";
-	name = "Lock Control";
-	normaldoorcontrol = 1;
-	pixel_y = 25;
-	specialfunctions = 4
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/mineral/titanium/blue,
-/area/station/commons/toilet)
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "rVn" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -51006,6 +52769,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#5d341f";
+	dir = 1
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -51032,7 +52800,14 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "rZA" = (
-/turf/open/floor/iron/dark/diagonal,
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe";
+	pixel_x = -4
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "rZR" = (
 /obj/effect/turf_decal/bot{
@@ -51051,6 +52826,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/eighties,
 /area/station/maintenance/abandon_arcade)
+"sai" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "barShutters";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/grass,
+/area/station/service/bar)
 "sam" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -51124,8 +52907,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "sdf" = (
-/obj/structure/railing,
-/turf/open/floor/glass,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 10
+	},
+/obj/structure/hedge,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/station/service/bar)
 "sdl" = (
 /obj/structure/disposalpipe/segment,
@@ -51224,10 +53015,7 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "seE" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "sfd" = (
 /obj/structure/cable,
@@ -51265,11 +53053,25 @@
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
 "sgb" = (
-/obj/structure/chair{
-	name = "Judge"
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
+/obj/machinery/computer/centcom_announcement/nri_raider{
+	name = "Judge announcement console";
+	desc = "A console used for making priority Internal Affairs reports.";
+	command_name = "High Court Annoncement";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/courtroom)
 "sgl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -51279,7 +53081,7 @@
 /area/station/science/genetics)
 "sgs" = (
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/wood/tile,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "sgA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -51619,6 +53421,20 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
+"ssf" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "ssN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -51687,11 +53503,16 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "svu" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
+/obj/effect/turf_decal/siding/white{
+	dir = 10
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "svy" = (
 /obj/machinery/door/airlock/external{
@@ -51706,7 +53527,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "swt" = (
 /obj/structure/cable,
@@ -51803,21 +53630,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "szo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "szE" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -51856,9 +53677,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "sAD" = (
-/obj/effect/turf_decal/trimline/white/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 2
+	},
 /obj/item/kirbyplants/random/fullysynthetic,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1;
+	color = "#9FED58"
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half";
+	dir = 4
+	},
 /area/station/hallway/secondary/service)
 "sAE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52026,11 +53856,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "sHg" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
+/obj/machinery/door/airlock/bathroom{
+	name = "Cabin 2"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/commons/toilet)
 "sHn" = (
 /turf/open/floor/plating,
@@ -52086,6 +53916,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"sJx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white/corner,
+/obj/item/reagent_containers/cup/glass/waterbottle/empty{
+	pixel_x = 12;
+	pixel_y = 17
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "sJE" = (
 /obj/structure/railing/corner/end{
 	dir = 8
@@ -52103,6 +53950,25 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"sJO" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/effect/spawner/random/bureaucracy/pen,
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "sKh" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
@@ -52209,12 +54075,17 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "sNu" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "sNE" = (
 /obj/structure/tank_holder/extinguisher,
@@ -52269,6 +54140,17 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
+"sOC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Dormitory South"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/commons/dorms)
 "sOI" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -52464,10 +54346,23 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "sVA" = (
-/obj/effect/spawner/random/entertainment/arcade{
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/dorms)
 "sVI" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -52592,7 +54487,7 @@
 /area/station/hallway/primary/fore)
 "sYX" = (
 /obj/machinery/door/airlock/bathroom{
-	name = "Restroom"
+	name = "Cabin 2"
 	},
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms)
@@ -52696,6 +54591,13 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"tbk" = (
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
+	},
+/obj/structure/flora/grass/jungle,
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "tbn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -52717,10 +54619,11 @@
 /area/station/maintenance/port/aft)
 "tbx" = (
 /obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 6
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/structure/flora/bush/jungle/b/style_random{
+	pixel_y = 17;
+	pixel_x = 5
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "tbT" = (
@@ -52777,7 +54680,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white{
+	dir = 4;
+	color = ы
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "tdM" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -52873,6 +54780,20 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"tgs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 6
+	},
+/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/red,
+/area/station/security/courtroom)
 "tgv" = (
 /obj/machinery/button/door{
 	id = "kanyewest";
@@ -52900,15 +54821,13 @@
 /turf/open/floor/iron/dark/side,
 /area/station/commons/dorms)
 "thd" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
+/obj/structure/chair/wood/wings{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 6
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/red,
 /area/station/security/courtroom)
 "the" = (
 /obj/structure/rack,
@@ -52938,13 +54857,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
+"tic" = (
+/mob/living/basic/carp/passive{
+	name = "Mooncarp"
+	},
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
+	},
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "tix" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	icon_state = "tile_corner";
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 2
+	},
+/obj/structure/window/reinforced/spawner/directional/west{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/railing,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "tiR" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 8
@@ -52962,7 +54900,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_corner";
+	dir = 1
+	},
 /area/station/maintenance/fore/lesser)
 "tjy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -52994,7 +54936,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1;
+	icon_state = "darkcorner"
+	},
 /area/station/commons/dorms)
 "tjM" = (
 /obj/machinery/camera/directional/north{
@@ -53058,6 +55003,14 @@
 /obj/machinery/autolathe,
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
+"tlq" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "tly" = (
 /obj/machinery/computer/records/security,
 /turf/open/floor/iron/dark,
@@ -53282,7 +55235,10 @@
 /area/station/security/execution/transfer)
 "ttB" = (
 /obj/structure/cable,
-/obj/structure/railing/corner/end{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -53348,10 +55304,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
 "tuG" = (
-/obj/structure/railing{
-	dir = 10
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/glass,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "tuZ" = (
 /obj/machinery/button/door{
@@ -53405,7 +55364,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "tvg" = (
 /obj/structure/table/wood,
@@ -53426,17 +55385,14 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "twX" = (
-/obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/dorms)
 "txy" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 10
-	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "txB" = (
@@ -53475,6 +55431,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"tyW" = (
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "tzt" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
@@ -53606,9 +55570,19 @@
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "tDQ" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 2
+	},
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "tEk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -53635,6 +55609,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"tFw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/large,
+/area/station/security/courtroom)
 "tGg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53843,12 +55821,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "tMQ" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
 	},
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/obj/structure/flora/rock/pile,
+/obj/structure/flora/ocean/longseaweed,
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "tMV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -53858,7 +55837,9 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "tNg" = (
 /obj/structure/table,
@@ -53921,7 +55902,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/hydroponics)
 "tPJ" = (
-/turf/open/floor/wood/tile,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
 "tPO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -54059,30 +56041,28 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "tTx" = (
-/obj/structure/table/wood,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "tTQ" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
-"tUx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/side{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/area/station/commons/dorms)
+/turf/open/floor/wood/large,
+/area/station/service/bar)
+"tUx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "tUV" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	color = "#777575";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "tUY" = (
@@ -54138,11 +56118,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar/directional/east{
+/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/light/directional/west{
 	dir = 1
 	},
-/obj/effect/landmark/start/bouncer,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/dark/end,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "tYe" = (
 /obj/effect/turf_decal/siding/wood{
@@ -54196,6 +56184,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/mob/living/basic/lightgeist{
+	name = "xeelorh"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
@@ -54274,10 +56265,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "ubs" = (
-/obj/structure/railing{
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/comfy{
+	color = "#8a3033";
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/assistant,
+/mob/living/carbon/human/species/monkey/punpun,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/glass,
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "ubw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -54383,6 +56383,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/station/solars/port/fore)
+"ufL" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/item/kirbyplants/synthetic/plant28,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "uga" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -54425,6 +56431,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/parquet,
 /area/station/commons/dorms)
+"ujc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
+"ujY" = (
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	color = "#777575";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	color = "#777575";
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "ukX" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
@@ -54475,17 +56505,13 @@
 /turf/open/floor/wood/tile,
 /area/station/common/pool)
 "umv" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/shower/directional/east,
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side,
-/area/station/commons/dorms)
+/obj/structure/drain,
+/turf/open/floor/iron/white/small,
+/area/station/commons/toilet)
 "umx" = (
 /obj/structure/chair/sofa/right/brown,
 /obj/item/toy/plush/moth{
@@ -54508,14 +56534,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "unc" = (
-/obj/structure/flora/bush/fullgrass,
-/obj/structure/flora/ocean/coral,
-/obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	color = "#777575";
+	dir = 1
 	},
-/obj/structure/window/spawner/directional/south,
-/turf/open/water/overlay,
-/area/station/service/bar)
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "uoh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/preopen{
@@ -54535,15 +56560,15 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "uoD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plastic,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "upa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54831,9 +56856,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
 "uxR" = (
-/obj/structure/urinal/directional/north,
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "uyb" = (
 /obj/structure/closet/secure_closet/research_director,
@@ -55010,7 +57040,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "uBY" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
@@ -55031,13 +57060,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/genetics)
 "uDn" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/generic_maintenance_landmark,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "uDN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -55071,20 +57101,21 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "uEH" = (
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	dir = 4
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "uEO" = (
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/commons/fitness)
 "uFd" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool/cobble/side{
@@ -55124,7 +57155,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/service/bar)
 "uGy" = (
 /obj/structure/cable,
@@ -55189,9 +57222,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "uHY" = (
-/obj/effect/turf_decal/trimline/green/line,
 /obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/plastic,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 10
+	},
+/obj/item/kirbyplants/random/fullysynthetic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "uIr" = (
 /obj/structure/disposalpipe/segment{
@@ -55208,24 +57244,43 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "uIw" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "uIE" = (
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -5;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "uJk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/spawner/random/vending/snackvend,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 4
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark/end,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
+	},
 /area/station/service/bar)
 "uJF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -55239,17 +57294,26 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"uJU" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/station/commons/dorms)
 "uKr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/library)
 "uKA" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	dir = 8
+/obj/structure/table/wood/fancy/red,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/red,
 /area/station/security/courtroom)
 "uLz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -55299,9 +57363,16 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/starboard)
 "uMW" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/spawner/random/entertainment/cigarette,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/sofa/left{
+	color = "#8a3033";
+	dir = 8
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 6
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "uMY" = (
 /obj/structure/bodycontainer/morgue,
@@ -55324,13 +57395,28 @@
 /turf/open/floor/iron/dark,
 /area/station/security/corrections_officer)
 "uNl" = (
-/obj/structure/flora/bush/sparsegrass,
-/obj/effect/spawner/liquids_spawner{
-	reagent_list = list(/datum/reagent/water=600)
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
 	},
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/west,
-/turf/open/water/overlay,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 10
+	},
+/obj/structure/table/wood/fancy,
+/obj/item/instrument/eguitar{
+	pixel_x = 5
+	},
+/obj/item/instrument/guitar{
+	pixel_x = -7
+	},
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_corner";
+	dir = 4
+	},
 /area/station/service/bar)
 "uNp" = (
 /obj/structure/chair/plastic{
@@ -55620,10 +57706,15 @@
 /area/station/command/bridge)
 "uUl" = (
 /obj/machinery/light/directional/east,
-/obj/item/kirbyplants/random,
-/obj/structure/window/spawner/directional/south,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/theater)
+/mob/living/basic/carp/mega/shorki{
+	name = "Yuuria"
+	},
+/obj/effect/spawner/liquids_spawner{
+	reagent_list = list(/datum/reagent/water=600)
+	},
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/cobblestone,
+/area/station/service/bar)
 "uUn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -55634,14 +57725,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "uVD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/door/airlock/service{
 	name = "Service Hall"
 	},
@@ -55698,8 +57786,16 @@
 /obj/structure/mirror/directional/north,
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
+"uWN" = (
+/obj/structure/closet/crate/wooden/storage_barrel,
+/obj/item/storage/box/syndie_kit/chameleon,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "uXt" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Dock"
@@ -55788,11 +57884,12 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/garden)
 "vaD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/structure/flora/rock/pile/jungle/style_random,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "plastitanium"
 	},
-/obj/structure/noticeboard/directional,
-/turf/closed/wall,
 /area/station/service/bar)
 "vaK" = (
 /obj/machinery/requests_console{
@@ -55878,9 +57975,6 @@
 /obj/item/hairbrush,
 /obj/item/clothing/sextoy/buttplug{
 	icon_state = "buttplug_metal_small"
-	},
-/obj/item/clothing/sextoy/fleshlight{
-	icon_state = "fleshlight_yellow"
 	},
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
@@ -56055,12 +58149,27 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
+"viO" = (
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = 9;
+	pixel_y = -3
+	},
+/obj/structure/table,
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "viZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vjl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -56105,14 +58214,11 @@
 "vkr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vks" = (
-/obj/machinery/hydroponics/soil,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "vkx" = (
@@ -56131,25 +58237,26 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "vkQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plastic,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "vlf" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Bar Door";
-	req_access = list("bar")
+/obj/structure/window/reinforced/spawner/directional/south{
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/chair{
+	name = "Defendant"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/service/bar)
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "vln" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -56284,11 +58391,7 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "vqb" = (
-/obj/machinery/holopad,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vqc" = (
 /turf/closed/wall/r_wall,
@@ -56394,6 +58497,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"vtX" = (
+/obj/effect/landmark/start/bartender,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
+/area/station/service/bar)
 "vul" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/machinery/door/firedoor,
@@ -56434,8 +58543,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "vvP" = (
 /obj/machinery/light/small/broken/directional/south,
 /turf/open/floor/plating,
@@ -56598,7 +58710,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/iron/stairs/old{
+	color = "#784936"
+	},
 /area/station/service/bar)
 "vBq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56664,7 +58778,6 @@
 /area/station/hallway/primary/starboard)
 "vCQ" = (
 /obj/effect/decal/cleanable/crayon/rune4,
-/obj/item/toy/plush/maru,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vDl" = (
@@ -56845,6 +58958,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"vGE" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/item/kirbyplants/synthetic/plant27,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "vGP" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Shooting Range"
@@ -56886,13 +59006,10 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "vHL" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/effect/landmark/start/lawyer,
-/turf/open/floor/wood/tile,
+/obj/machinery/photocopier,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "vHR" = (
 /obj/machinery/door/airlock{
@@ -56904,9 +59021,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "vIc" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "vIe" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool/cobble/corner{
@@ -56914,20 +59033,11 @@
 	},
 /area/station/common/pool)
 "vIU" = (
-/obj/structure/table/glass,
-/obj/item/food/grown/wheat,
-/obj/item/food/grown/watermelon,
-/obj/item/food/grown/watermelon,
-/obj/item/food/grown/watermelon,
-/obj/item/food/grown/citrus/orange,
-/obj/item/food/grown/grapes,
-/obj/item/food/grown/cocoapod,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/machinery/light/directional/east{
+	dir = 8
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "vJd" = (
 /obj/machinery/computer/prisoner/management,
@@ -57005,11 +59115,9 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "vLW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/diagonal,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vLX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57049,9 +59157,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "vNb" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/spawner/random/entertainment/deck,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/sofa/right{
+	color = "#8a3033";
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "vNl" = (
 /obj/machinery/button/door/directional/north{
@@ -57081,11 +59191,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "vNZ" = (
-/obj/structure/railing{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vOb" = (
 /obj/structure/disposalpipe/segment{
@@ -57120,17 +59232,23 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vOV" = (
-/obj/structure/chair/stool/bar/directional/east{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/stool/bar/directional/east{
+	dir = 1
+	},
+/obj/structure/chair/comfy{
+	color = "#8a3033";
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "vPP" = (
 /obj/effect/turf_decal/tile/blue{
@@ -57167,12 +59285,21 @@
 /area/station/hallway/secondary/exit)
 "vQD" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/security/telescreen/prison,
 /obj/machinery/button/door/directional/west{
 	id = "law_shatters";
 	name = "Shutters"
 	},
-/turf/open/floor/wood/tile,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/item/stamp/law,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "vRc" = (
 /obj/structure/cable,
@@ -57230,12 +59357,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "vSB" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/blue,
 /area/station/service/theater)
 "vTL" = (
 /obj/structure/cable,
@@ -57250,11 +59373,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "vUw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "vUH" = (
 /obj/machinery/firealarm/directional/west,
@@ -57278,19 +59401,29 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "vVj" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/wood/large{
+	icon_state = "wood_tile"
+	},
 /area/station/service/bar)
 "vVA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/commons/fitness)
 "vVG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57383,6 +59516,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"vYM" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "vYW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57472,6 +59614,14 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
+"wdp" = (
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 9
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "wdv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -57627,12 +59777,13 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "wkI" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 9
+/obj/machinery/door/poddoor/preopen{
+	id = "barShutters";
+	name = "Privacy Shutters"
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/garden)
+/area/station/service/bar)
 "wlP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 10
@@ -57717,7 +59868,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_half"
+	},
 /area/station/service/bar)
 "wqp" = (
 /obj/structure/disposalpipe/segment{
@@ -57745,16 +59898,36 @@
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_cafeteria)
 "wqD" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium/blue,
-/area/station/commons/toilet)
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "wqH" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/spawner/xmastree,
-/turf/open/floor/glass,
+/obj/structure/table/wood/fancy,
+/obj/structure/musician/piano{
+	icon_state = "piano"
+	},
+/obj/item/flashlight/flare/candle/vanilla{
+	pixel_x = 4;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -2;
+	pixel_y = 10
+	},
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784938";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "wqP" = (
 /turf/open/floor/carpet,
@@ -57800,14 +59973,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "wsZ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/item/pen,
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/wood/large{
+	icon_state = "wood_tile"
+	},
+/area/station/service/bar)
 "wtb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -57818,7 +59993,11 @@
 /area/station/medical/cryo)
 "wuA" = (
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "wuD" = (
 /obj/machinery/camera/directional/east{
@@ -57951,12 +60130,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wxY" = (
-/obj/structure/chair/sofa/right,
-/obj/effect/landmark/start/mime,
 /obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/white/side{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/dresser,
+/turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "wyl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -57978,8 +60158,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "wyv" = (
-/obj/vehicle/sealed/mecha/ripley/paddy/preset,
-/turf/open/floor/iron/recharge_floor,
+/obj/machinery/light/directional/west,
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/security/mechbay)
 "wyW" = (
 /obj/machinery/door/airlock/security/glass{
@@ -58058,19 +60241,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wBb" = (
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/item/beacon,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "wBd" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "wBl" = (
 /turf/closed/wall/r_wall,
@@ -58364,12 +60543,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "wJK" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/white/end,
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "wJQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -58422,10 +60606,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "wLU" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
 /area/station/commons/fitness)
 "wMe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58472,19 +60657,18 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "wOu" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/mail_sorting/service/theater,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "wOK" = (
 /obj/structure/rack,
@@ -58507,9 +60691,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "wPu" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "wPx" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -58699,10 +60886,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "wSS" = (
-/obj/machinery/photocopier,
-/obj/structure/cable,
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#777575";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "wTh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -58786,7 +60977,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/wood/tile,
+/turf/open/floor/wood/large,
 /area/station/service/lawoffice)
 "wUr" = (
 /obj/structure/disposalpipe/segment{
@@ -58979,9 +61170,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "wZS" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/garden)
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/puzzle/keycard/library,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "xac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
@@ -59147,9 +61344,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "xgQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/service{
 	name = "Theatre"
 	},
@@ -59253,17 +61450,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "xjZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/side{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/area/station/commons/dorms)
+/obj/structure/table/wood,
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "xka" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/mapping_helpers/broken_floor,
@@ -59346,14 +61538,18 @@
 "xoZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/side{
+/obj/structure/railing{
 	dir = 1
 	},
-/area/station/commons/dorms)
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "xpa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -59463,7 +61659,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/herringbone,
+/obj/structure/chair/sofa/left{
+	color = "#8a3033";
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/station/service/bar)
 "xsP" = (
 /obj/structure/table,
@@ -59502,8 +61702,8 @@
 /turf/open/floor/iron,
 /area/station/service/barber)
 "xtV" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "xux" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
@@ -59533,6 +61733,19 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/maintenance/central/lesser)
+"xuK" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/bed/pod,
+/obj/item/bedsheet/clown,
+/obj/item/pillow/clown{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/service/theater)
 "xuM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -59602,12 +61815,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "xxM" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/machinery/firealarm/directional/south,
+/obj/structure/hedge,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/grass,
 /area/station/service/bar)
 "xxX" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -59627,12 +61851,11 @@
 /turf/open/space/basic,
 /area/space)
 "xzk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plastic,
+/turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "xzr" = (
 /turf/open/floor/circuit/telecomms,
@@ -59738,8 +61961,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/brig)
 "xDp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -59835,14 +62060,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "xHD" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_corner";
+	dir = 4
+	},
+/area/station/maintenance/fore/lesser)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -59892,7 +62120,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xLr" = (
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "xLC" = (
 /obj/structure/cable,
@@ -60058,7 +62286,10 @@
 "xPP" = (
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/wood,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark/smooth_large{
+	icon_state = "textured_dark_large"
+	},
 /area/station/hallway/secondary/service)
 "xPV" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -60251,9 +62482,7 @@
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
 "xUC" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "xUI" = (
@@ -60274,18 +62503,17 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "xVA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "xWd" = (
 /obj/structure/cable,
@@ -60308,16 +62536,10 @@
 "xWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/iron/stairs/old{
+	color = "#b0b0b0"
 	},
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/commons/dorms)
+/area/station/commons/fitness)
 "xWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -60433,11 +62655,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "yaJ" = (
-/obj/structure/railing/corner{
-	dir = 4
+/obj/structure/chair{
+	name = "Defendant"
 	},
-/turf/open/floor/iron/white/herringbone,
-/area/station/service/bar)
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/maintenance/fore/lesser)
 "yaT" = (
 /obj/structure/sign/warning/no_smoking{
 	pixel_x = -25
@@ -60484,6 +62708,16 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
+"ycJ" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/personal/cabinet{
+	name = "Law closet"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "ycY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -60521,17 +62755,25 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "ydP" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/effect/landmark/start/hangover,
-/obj/item/toy/cards/deck{
-	pixel_y = 4
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 1
 	},
-/turf/open/floor/iron/white/herringbone,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "yee" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/machinery/light/directional/east,
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Law Office";
+	name = "Law Office Fax Machine"
+	},
+/turf/open/floor/wood/large,
+/area/station/service/lawoffice)
 "yer" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light/directional/south,
@@ -60586,12 +62828,17 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "yeQ" = (
-/obj/machinery/mech_bay_recharge_port{
+/obj/structure/chair/pew{
 	dir = 1
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/security/mechbay)
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/railing{
+	name = "wooden railing";
+	color = "#784936";
+	dir = 2
+	},
+/turf/open/floor/wood/tile,
+/area/station/security/courtroom)
 "yeY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -60640,6 +62887,12 @@
 /obj/structure/flora/ocean/longseaweed,
 /turf/open/water/overlay,
 /area/station/science/breakroom)
+"ygj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "ygs" = (
 /obj/effect/landmark/start/captain,
 /obj/structure/chair/office,
@@ -75086,9 +77339,9 @@ sUX
 sUX
 alU
 aoS
-amC
-aom
-rta
+hKJ
+qEl
+usr
 aol
 alU
 auZ
@@ -75346,7 +77599,7 @@ aoR
 apO
 aqM
 alU
-aol
+amC
 alU
 auY
 bvN
@@ -75600,10 +77853,10 @@ xzh
 xzh
 alU
 aoT
-hKJ
-ahY
+asS
+aiR
 alU
-aol
+amC
 alU
 ava
 bvO
@@ -75860,7 +78113,7 @@ alU
 alU
 aiP
 alU
-jXl
+alU
 alU
 alU
 alU
@@ -76116,17 +78369,17 @@ uRx
 uRx
 ali
 aiR
-amC
-aol
 alU
+iPz
+gpt
 aAS
-aRo
+alU
 vks
 tbx
-aAQ
-aAQ
+lXl
+wdp
 aIO
-aAQ
+ahY
 azF
 aLj
 aLC
@@ -76372,14 +78625,14 @@ xzh
 uRx
 uRx
 ali
-ajw
-amC
-aol
+aiR
 alU
+amC
+aTk
 aAT
+alU
 fFQ
-fFQ
-fFQ
+lfY
 iWe
 tUV
 rdH
@@ -76630,17 +78883,17 @@ alU
 alU
 alU
 vvZ
-aol
-aol
+rKT
+iie
 atr
-aAU
+aol
 wZS
-wZS
-wZS
+unc
+ujY
 xUC
-aAQ
+xUC
 aBw
-aBM
+qtR
 azF
 azF
 azF
@@ -76887,22 +79140,22 @@ aoj
 hKJ
 apP
 ajw
-amC
-aol
 alU
+uWN
+iEe
 bbV
+alU
 miW
-miW
-miW
+qAW
 hre
-aAQ
+hre
 aFP
 arC
 ase
-aAx
-aAx
+wSS
 aAx
 aKm
+aAQ
 avi
 aNj
 aNR
@@ -77144,22 +79397,22 @@ aol
 aol
 aol
 ajK
-aol
-aol
 alU
+hKJ
+aRo
 koe
-wkI
+alU
 mbo
+aIP
+kGL
+qpq
+aBG
+hre
+aIS
+tyW
+aBM
 txy
 aAQ
-aAQ
-aBG
-aAQ
-aIS
-aAQ
-aBM
-aAQ
-aKn
 aLE
 avG
 aOm
@@ -77401,22 +79654,22 @@ aok
 anJ
 anJ
 aFJ
-apD
-aol
 alU
 alU
 alU
 alU
 alU
+alU
+icj
 alU
 aAP
 iHT
-aAQ
-aAQ
+kat
+qxK
 aFO
 aHA
-aIT
 azF
+ufL
 uBY
 avG
 aOl
@@ -77655,7 +79908,7 @@ alR
 alR
 alR
 aom
-amC
+aoX
 apP
 amC
 amC
@@ -90770,7 +93023,7 @@ cvU
 vHp
 dFo
 dFo
-arf
+dFo
 fYp
 aBz
 cvP
@@ -91022,12 +93275,12 @@ aiX
 fMc
 iqj
 omR
-tPJ
+qzn
 feT
 tPJ
 vQD
 wUq
-arf
+dFo
 sfd
 aBz
 cvP
@@ -91278,13 +93531,13 @@ uAe
 nWC
 fMc
 fIE
-tPJ
-tPJ
+nSR
+qzn
 feT
 tPJ
 eSp
 oPX
-arf
+dFo
 tHD
 lwA
 cvP
@@ -91509,9 +93762,9 @@ nxl
 slB
 kdV
 wRw
-bgq
+qXA
 pCQ
-bgq
+qzO
 agn
 jQy
 vEA
@@ -91534,14 +93787,14 @@ hkA
 hkA
 ukX
 lrf
-tPJ
+kce
 kce
 rFq
 feT
 kYI
-xHD
+kce
 sgs
-arf
+dFo
 fYp
 aBz
 cvP
@@ -91766,9 +94019,9 @@ kqM
 eER
 nkf
 wRw
-bgq
-bgq
-bgq
+gho
+rpn
+rQN
 eYF
 meO
 vEA
@@ -91793,12 +94046,12 @@ qcN
 fMc
 vHL
 mRd
-tPJ
+fDX
 oFL
-tPJ
-tPJ
-tPJ
-arf
+pEt
+yee
+ijM
+dFo
 fYp
 aBz
 cvP
@@ -92024,7 +94277,7 @@ lye
 qTa
 wRw
 dOw
-bgq
+bPB
 bgq
 agn
 fHL
@@ -92047,15 +94300,15 @@ avD
 uaj
 uaj
 avD
-avD
-wSS
-qtR
+fMc
+dFo
+dFo
 nEJ
-lfY
-wsZ
-lUg
-tTQ
-arf
+mek
+dFo
+dFo
+dFo
+dFo
 fYp
 sRr
 aAX
@@ -92305,24 +94558,24 @@ gPF
 ajg
 qIj
 avD
-dFo
-dFo
+ycJ
+eKV
 ore
-mek
-dFo
-dFo
-dFo
-arf
+gnJ
+aTl
+ajo
+kjJ
+bFS
 rYH
 nMd
 lvJ
-osW
+lvJ
 aDG
 aFd
-fDX
+lvJ
 aHH
 aJg
-aKo
+lUZ
 aLO
 gWZ
 aOE
@@ -92564,23 +94817,23 @@ peH
 avD
 dZA
 gwP
-rij
+lew
 fPV
 thd
 ajo
 xjZ
-azc
-oNi
+tDQ
+gEK
 akV
 aBz
-aAh
-aAh
-aAh
-aAh
-aAh
-aAh
-aAh
-aLR
+uJU
+aGk
+sOC
+aGk
+gXT
+pgT
+nYI
+aMg
 jpA
 aOE
 aJn
@@ -92819,23 +95072,23 @@ syF
 sDb
 otD
 avD
-ajp
 seE
-uIw
+tFw
+lew
 rpf
 uKA
-amr
-nFJ
-awr
+ajo
+cwQ
+gdE
 gEK
-qEl
-umv
+awr
+aBz
 aAh
-aGk
 aAh
-rVc
 aAh
-aJz
+aAh
+aAh
+aAh
 aAh
 aLQ
 bUm
@@ -93078,14 +95331,14 @@ cLp
 oXK
 luG
 cyc
-rij
+lew
 lLO
 cLN
-amr
+ajo
 nFJ
-awr
+gHt
 flw
-qEl
+awr
 lVO
 aAh
 aDQ
@@ -93334,22 +95587,22 @@ wDv
 mBH
 avD
 oMv
-cyc
-rij
+goT
+lew
 dQM
 wBb
 oqj
 cOk
+pQq
+dHe
 awr
-gEK
-qEl
-cqO
+aBz
 aAh
-hwE
+oWE
 cFF
 hwE
 jbp
-hwE
+aDu
 aAh
 ioJ
 ova
@@ -93589,24 +95842,24 @@ avD
 avD
 hxT
 avD
-avD
+oXK
 sgb
-cyc
-rij
+ijT
+uIw
 piX
-cLN
-amr
-dHe
+jXl
+ajo
+hhb
 qsM
-qsM
+aLR
 axV
 qhl
-wqD
+sHg
 jms
 tdz
 qwn
 hth
-hth
+jPO
 mHQ
 sNW
 ova
@@ -93841,21 +96094,21 @@ ihE
 oKQ
 nXO
 wyv
-yeQ
-hwi
 mwk
+hwi
+tlq
 hEb
 rrb
 hKq
 fDM
 uEH
-cwQ
+uIw
 arG
 nQe
-amr
-tUx
-axV
-awr
+ajo
+cwQ
+yeQ
+aLR
 awr
 sXA
 aAh
@@ -94095,15 +96348,15 @@ nOk
 utT
 ljc
 kxi
-ftX
+oeE
 pxu
 mSW
-aTl
-hfM
 mwk
-nas
+hfM
+aaU
+xHD
 anF
-ahn
+mUK
 ajm
 miY
 ajp
@@ -94112,12 +96365,12 @@ fFe
 ajo
 hYp
 axX
-awr
+aLR
 awr
 uGP
 aAh
-aGn
-aGn
+nqP
+umv
 aGn
 aAh
 uxR
@@ -94354,42 +96607,42 @@ ljc
 kxi
 ftX
 kxi
-kxi
-kxi
-oOI
+viO
 mwk
+oOI
+aGH
 nas
+gOB
+aiA
+mRn
+vlf
 ahn
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
+gui
+rLb
+ajo
 hCy
-axV
-awr
+tgs
+aLR
 awr
 tgF
 aAh
 alg
 aDT
-aDT
+jAi
 lIJ
 wuA
 aAh
 aJC
 aJC
-aJC
-aQg
-aJC
-aJC
-aQg
+wkI
+sai
+wkI
 aJC
 aJC
-aQg
 aJC
+sai
+wkI
+sai
 aJC
 gSC
 cRi
@@ -94610,43 +96863,43 @@ hrl
 lBo
 cIr
 pZa
-yee
 taC
-qXA
-knr
+fog
 mwk
+knr
+aGH
 nas
-ahn
-pMl
-anF
-anF
-tDQ
-asb
-asb
-ahn
-ckA
-axV
-awr
+vGE
+aiA
+oiB
+aiA
+aiA
+aiA
+aiA
+aiA
+rQR
+rQR
+hWz
 awr
 aBA
 aAh
 elT
 aGp
-aGp
+iaQ
 aAh
 uWK
 sHg
 pxf
 qRG
 lrc
-jeE
+nEz
 lmF
 iJl
 hQT
 vVj
-lmF
+aqU
 rSM
-vVj
+aJz
 aJC
 ikq
 iKz
@@ -94870,21 +97123,21 @@ mwk
 mwk
 mwk
 mwk
-mwk
-mwk
+gSm
+aGH
 hdP
-ahn
+amr
 asb
 lEl
-tix
-lhD
+mUK
+atV
 gJP
 atV
-avw
+mUK
 awy
 axQ
 azj
-awr
+tPO
 qVn
 aAh
 aAh
@@ -94896,13 +97149,13 @@ aAh
 gKP
 fke
 tXv
-jeE
+lCO
 gFP
 uIE
 nCw
-mzs
-gFP
-hQT
+tTQ
+iXa
+icT
 mzs
 aJC
 aYV
@@ -95126,20 +97379,20 @@ xDc
 pMl
 wPu
 vIc
-anF
-anF
-anF
+hBQ
+wqD
+osW
 tji
 pGo
-anF
+yaJ
 apu
-ahn
-ahn
-ahn
-ahn
-ahn
+aiA
+aiA
+aiA
+aiA
+aiA
 lVo
-axV
+uEO
 sed
 awr
 tgF
@@ -95153,12 +97406,12 @@ pbn
 rZA
 rEY
 nxn
-jeE
-geS
+ryq
+aKo
 ocj
 uMW
-pJL
-geS
+tTQ
+iXa
 vNb
 pJL
 aJC
@@ -95379,22 +97632,22 @@ aiX
 rch
 hei
 vvi
+pOR
 anc
-anc
-anc
-anc
+pOR
+pOR
 kUu
 aBB
-aBB
+ssf
 nCm
-anc
+cqO
 anD
 qps
-ahn
-eba
+aiA
+otE
 gsX
-cJf
-arf
+gsX
+dBA
 xWt
 vVA
 sed
@@ -95409,13 +97662,13 @@ pqO
 vLW
 hKj
 gDf
-nxn
-xtV
-jeE
-jeE
-jeE
-jeE
-xtV
+aIT
+liv
+aKn
+aKn
+aKn
+rVc
+kYe
 jxM
 xxM
 aJC
@@ -95634,26 +97887,26 @@ afA
 xzh
 aiX
 aiX
-aiA
-aiA
+aiX
+aiX
 gua
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
-ahn
+aiX
+aiX
+aiX
+aiX
+aiA
+aiA
+aiA
+aiA
+aiA
+aiA
+aiA
 fjj
-pvj
-wLU
-arf
+eba
+eba
+lmD
 fYT
-axV
+uEO
 sed
 awr
 twX
@@ -95663,18 +97916,18 @@ uGk
 mjr
 aJC
 hTl
-gdE
-rZA
+vLW
+vtX
 mhT
-nxn
+aIT
 xtV
 fyb
 vNZ
 tuG
 kUA
-iXa
+geS
 svJ
-jxM
+roQ
 nHV
 aYV
 iKz
@@ -95893,24 +98146,24 @@ sUX
 arq
 mEU
 nfa
-vUw
+csZ
 fPr
-arq
-ihj
+sJx
+cJf
 hCl
 fpc
+aPP
 rcV
 rcV
-rcV
-rcV
+pvj
 mPD
 ihj
-eba
+aap
 tTx
-wLU
-arf
-iWV
-axV
+eba
+lmD
+xoZ
+uEO
 sed
 awr
 uPR
@@ -95924,13 +98177,13 @@ mCu
 doM
 pvi
 vOV
-xtV
+lCO
 ezJ
 wqH
 sdf
 ydP
-rxc
-jeE
+iXa
+rij
 rwN
 aQg
 alu
@@ -96153,21 +98406,21 @@ blD
 csZ
 gBW
 faG
-eba
+ckA
 tBQ
-pdD
+eba
+avw
 eba
 eba
-eba
-eba
+avw
 ttB
-tBQ
-eba
-aap
+qrz
+iWV
 csc
-arf
+csc
+tix
 xoZ
-kmR
+rst
 ibL
 aAp
 aBC
@@ -96177,17 +98430,17 @@ gHk
 dii
 ygd
 bby
-vlf
+mCu
 cle
 vaD
 abw
-jeE
+lCO
 qNT
 ubs
 fjc
 qhE
 geS
-jeE
+goX
 vAZ
 rLs
 aDe
@@ -96408,42 +98661,42 @@ arq
 aMp
 bSp
 csZ
-blD
-faG
+qwT
+iPm
+jyz
+nVQ
 eba
+eba
+eba
+eba
+eba
+gon
 fYk
-eba
-eba
-eba
-eba
-eba
-dch
-fYk
-eba
+fnI
 jGC
-arf
-arf
-arf
+sJO
+oqm
+aAU
 uEO
-aAo
-aAo
-arf
+awr
+awr
+aBz
 cVb
 eAj
 myW
 aGy
 uHY
 aJC
-ijM
+mCu
 hin
-jeE
+cSk
 uJk
+ooO
+oPM
 jeE
-jeE
-jeE
-xtV
-jeE
-jeE
+iuN
+aFX
+oNK
 dsa
 rCB
 bby
@@ -96666,25 +98919,25 @@ sNu
 pCU
 hns
 hQC
-arq
+rzf
 dch
+gjD
+qGo
 mKW
 mKW
 mKW
+enW
 mKW
-mKW
-mKW
-mKW
-mKW
-qwT
-qwT
+gxj
 nny
-tjE
-tjE
+nny
+nny
+nny
+pqE
 tjE
 awr
 awr
-rst
+uGP
 cVb
 cVb
 goB
@@ -96694,13 +98947,13 @@ uVD
 pdv
 wqb
 cka
+lhD
 vkr
-vkr
-vkr
+pXQ
 viZ
-vkr
-vkr
-vkr
+nyd
+ygj
+rhN
 xsL
 liO
 aJC
@@ -96918,30 +99171,30 @@ xzh
 xzh
 xzh
 rQR
-rQR
-arq
-arq
-gjD
-arq
-arq
-gjD
-arq
-arq
+pdD
+pdD
+wLU
 rQR
 rQR
+rQR
+rQR
+rQR
+tUx
+vUw
+tUx
 jtf
 nWZ
 svu
-tTx
+eba
 xwG
 eba
-aAo
-kmR
+eba
+ujc
 dHa
 pxc
 awr
 awr
-awr
+fca
 ogn
 cVb
 vkQ
@@ -96952,13 +99205,13 @@ iCj
 lwz
 owl
 dPK
-xtV
-qRG
-qRG
-qRG
-yaJ
-jeE
-xtV
+oNi
+lUg
+vqb
+vqb
+vqb
+iXa
+jkm
 mVZ
 aJC
 bcr
@@ -97185,20 +99438,20 @@ aro
 aro
 aro
 aro
-rQR
+tUx
 orE
 mcS
 pxB
 wJK
-eba
-eba
+iJt
+psd
 aAo
-kmR
+qRO
 awr
 pxc
 awr
 awr
-awr
+fca
 fJg
 cVb
 kWH
@@ -97215,7 +99468,7 @@ nnO
 uNl
 vqb
 iXa
-jeE
+vNb
 oGT
 aJC
 aYV
@@ -97452,10 +99705,10 @@ oJU
 oJU
 lwY
 awr
-lmD
-lew
-oqm
-awr
+pxc
+pxc
+tPO
+fca
 roq
 cVb
 bkg
@@ -97466,13 +99719,13 @@ aFl
 aGD
 aHZ
 aCr
-dGd
-dGd
+tbk
+tic
 tMQ
-unc
-djV
+pdQ
+vqb
 rxc
-jeE
+dWQ
 hRx
 aJC
 aDA
@@ -97712,7 +99965,7 @@ awr
 mqD
 sVA
 faM
-awr
+uGP
 hmT
 cVb
 gQz
@@ -97722,14 +99975,14 @@ fHR
 afd
 qeP
 aHI
-oNK
+aCr
 dGd
-dGd
+tbk
 eLI
 pdQ
 liv
-rxc
-jeE
+oJD
+vYM
 rCc
 aJC
 aYV
@@ -97981,12 +100234,12 @@ mzV
 szo
 aCr
 oOL
-dGd
+lwv
 uUl
 eJr
 djV
 oAB
-vAZ
+wsZ
 iCL
 aJC
 hLC
@@ -98230,7 +100483,7 @@ qit
 arf
 xPP
 xLr
-goT
+tve
 aCr
 dMf
 lFf
@@ -98490,7 +100743,7 @@ xLr
 tve
 dKX
 eat
-lFf
+xuK
 dJg
 aCr
 njG
@@ -99000,8 +101253,8 @@ cIV
 abB
 arf
 aIl
-qzO
-pOR
+cRr
+aGP
 sAD
 aJI
 aKT
@@ -99257,7 +101510,7 @@ arf
 arf
 arf
 aQX
-qzO
+cRr
 aGB
 pUe
 aAe
@@ -99514,7 +101767,7 @@ nMQ
 ouE
 arf
 aKW
-qzO
+cRr
 eAT
 aHY
 aJI
@@ -99771,8 +102024,8 @@ qFG
 lmI
 arf
 aLd
-qzO
-pOR
+cRr
+aGP
 lnJ
 aJK
 wkw
@@ -100285,8 +102538,8 @@ ejB
 pzQ
 arf
 aDX
-cSk
-aGH
+cRr
+aGP
 qWZ
 srt
 aKX
@@ -100542,7 +102795,7 @@ arf
 arf
 arf
 fDD
-cSk
+cRr
 aGQ
 aIp
 aIp

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -47326,6 +47326,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
+"ozC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/hydroponics/garden)
 "ozD" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners{
 	dir = 1
@@ -79095,7 +79100,7 @@ ase
 wSS
 aAx
 aKm
-aAQ
+ozC
 avi
 aNj
 aNR

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -288,7 +288,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/wood/tile{
+	icon_state = "wood_large"
+	},
 /area/station/security/detectives_office)
 "adv" = (
 /obj/structure/chair/office{
@@ -847,11 +849,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/door/window/left/directional/south{
-	name = "Court Cell";
-	req_access = list("brig");
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -1176,6 +1173,12 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -1283,8 +1286,6 @@
 /area/station/cargo/office)
 "anc" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south{
 	dir = 4
 	},
@@ -1339,11 +1340,6 @@
 /area/station/maintenance/abandon_cafeteria)
 "anD" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
 	},
@@ -1357,21 +1353,13 @@
 "anF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/structure/table/reinforced,
-/obj/machinery/coffeemaker{
-	pixel_y = 13
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/item/reagent_containers/cup/coffeepot{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/item/coffee_cartridge/bootleg{
-	pixel_x = 8
-	},
-/obj/item/coffee_cartridge/bootleg{
-	pixel_x = 9;
-	pixel_y = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -1561,14 +1549,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -1909,6 +1893,12 @@
 	req_access = list("brig");
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -2047,10 +2037,16 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "ata" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kanyewest";
-	name = "Privacy Shutters"
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/detective,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
@@ -3679,10 +3675,6 @@
 /area/station/commons/dorms)
 "aBB" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 5
 	},
@@ -24334,9 +24326,6 @@
 /area/station/engineering/main)
 "cqO" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
 	},
@@ -24722,12 +24711,11 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "csZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_half"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall,
-/area/station/commons/fitness)
+/area/station/maintenance/fore/lesser)
 "cta" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4;
@@ -25986,8 +25974,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "cyP" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/iron/grimy,
+/obj/structure/chair/sofa/left{
+	color = "#4465a6"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "cyU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -26525,8 +26518,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cBy" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/iron/grimy,
+/obj/structure/chair/sofa/right{
+	color = "#4465a6"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "cBB" = (
 /obj/effect/landmark/event_spawn,
@@ -29616,12 +29614,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "dJm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "dJx" = (
@@ -32113,7 +32109,8 @@
 /area/station/engineering/break_room)
 "fjW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/grimy,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "fka" = (
 /obj/machinery/griddle,
@@ -33121,17 +33118,23 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
 "fUX" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/door/airlock/corporate{
+	name = "Court Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 10
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/maintenance/fore/lesser)
 "fVk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -33934,11 +33937,16 @@
 	},
 /area/station/holodeck/rec_center)
 "gua" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/brig)
 "gui" = (
 /obj/effect/turf_decal/siding/wood{
@@ -34557,9 +34565,19 @@
 "gOB" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/structure/table/reinforced,
-/obj/item/paper{
-	pixel_x = -2;
-	pixel_y = 1
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 8
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/machinery/coffeemaker{
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/cup/coffeepot{
+	pixel_x = -5;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
@@ -34693,16 +34711,24 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = -3;
-	pixel_y = 9
+/obj/machinery/light/directional/south{
+	dir = 1
+	},
+/obj/item/paper{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = 1
 	},
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = 6;
 	pixel_y = 3
 	},
-/obj/machinery/light/directional/south{
-	dir = 1
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -3;
+	pixel_y = 9
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
@@ -35077,12 +35103,16 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "hei" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	location = "Security"
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/brig)
 "hep" = (
 /obj/structure/table,
@@ -35181,6 +35211,10 @@
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = 7;
 	pixel_y = 8
+	},
+/obj/item/flashlight/lamp{
+	pixel_y = 15;
+	pixel_x = -5
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
@@ -35457,14 +35491,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "hns" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	location = "Security"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/commons/fitness)
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/iron/dark,
+/area/station/security/detectives_office)
 "hnt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -35644,12 +35677,18 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "huh" = (
-/obj/structure/table/wood,
 /obj/item/paper_bin{
 	pixel_y = 2
 	},
 /obj/item/pen,
-/turf/open/floor/iron/grimy,
+/obj/structure/chair/sofa/left{
+	color = "#4465a6";
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "huA" = (
 /obj/item/kirbyplants/random,
@@ -35942,6 +35981,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -36113,11 +36154,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation)
 "hGW" = (
-/obj/machinery/camera/directional/west,
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "hHq" = (
 /obj/structure/cable,
@@ -41524,8 +41564,6 @@
 /area/station/command/heads_quarters/hos)
 "kUu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
 "kUA" = (
@@ -42060,7 +42098,13 @@
 /area/station/commons/dorms)
 "lnB" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/grimy,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/obj/item/folder,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "lnJ" = (
 /obj/effect/turf_decal/trimline/green/line{
@@ -42552,15 +42596,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 10
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
@@ -43586,16 +43626,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/window/reinforced/spawner/directional/south{
-	pixel_y = -4
-	},
-/obj/structure/window/reinforced/spawner/directional/south{
-	pixel_y = -4;
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "mje" = (
@@ -44389,10 +44419,14 @@
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "mPd" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
+/obj/machinery/camera/directional/west,
+/obj/structure/chair/sofa/right{
+	color = "#4465a6"
 	},
-/turf/open/floor/iron/grimy,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "mPh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -44467,9 +44501,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/structure/window/reinforced/spawner/directional/south{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -45575,13 +45608,6 @@
 	},
 /area/station/service/bar)
 "nCm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail,
 /obj/effect/mapping_helpers/mail_sorting/service/law_office,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -45872,7 +45898,9 @@
 	fax_name = "Crew Complaints";
 	name = "Crew Complaints Fax"
 	},
-/turf/open/floor/iron/grimy,
+/obj/structure/table,
+/obj/item/folder,
+/turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "nGd" = (
 /obj/structure/disposalpipe/segment{
@@ -46192,7 +46220,7 @@
 /area/station/cargo/storage)
 "nQB" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "nQD" = (
 /obj/structure/sign/warning/pods/directional/north,
@@ -46796,10 +46824,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
@@ -47088,6 +47112,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "osW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_corner";
@@ -49094,9 +49122,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "pCU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 6
 	},
@@ -49185,6 +49210,7 @@
 /obj/structure/window/reinforced/spawner/directional/south{
 	pixel_y = -4
 	},
+/obj/item/kirbyplants/synthetic/plant27,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -49352,6 +49378,8 @@
 /area/station/maintenance/disposal)
 "pMl" = (
 /obj/effect/spawner/random/structure/girder,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -49394,8 +49422,6 @@
 /area/station/science/lab)
 "pOR" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -50096,6 +50122,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "qnW" = (
@@ -50143,13 +50170,6 @@
 "qps" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
@@ -51426,13 +51446,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rch" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/brigdoor/right/directional/west{
-	name = "Security Delivery";
-	req_access = list("brig")
+/obj/structure/chair/sofa/corner{
+	dir = 2;
+	light_color = null;
+	color = "#4465a6"
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet/blue,
+/area/station/security/detectives_office)
 "rcv" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
@@ -51842,15 +51865,6 @@
 "rrb" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 10
-	},
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp{
-	pixel_y = 15;
-	pixel_x = -5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 1
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
@@ -53420,10 +53434,6 @@
 /area/station/science/xenobiology)
 "ssf" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
 	},
@@ -54072,7 +54082,6 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "sNu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
@@ -54475,7 +54484,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "sYU" = (
 /obj/structure/cable,
@@ -54797,6 +54806,12 @@
 	name = "Privacy Shutters";
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "tgB" = (
@@ -54888,15 +54903,13 @@
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
 "tji" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_corner";
@@ -55994,10 +56007,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "tSc" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/folder,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/wood/tile{
+	icon_state = "wood_large"
+	},
 /area/station/security/detectives_office)
 "tSe" = (
 /obj/effect/turf_decal/box/blue,
@@ -58252,6 +58264,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/south{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "vln" = (
@@ -58519,6 +58537,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "vvd" = (
@@ -58869,17 +58888,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "vEV" = (
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kanyewest";
+	name = "Privacy Shutters"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/detective,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "vEZ" = (
@@ -58957,7 +58970,10 @@
 /area/station/science/lab)
 "vGE" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/item/kirbyplants/synthetic/plant27,
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -59019,6 +59035,8 @@
 /area/station/commons/toilet/locker)
 "vIc" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -59620,14 +59638,16 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "wdv" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/door/window/brigdoor/right/directional/west{
+	name = "Security Delivery";
+	req_access = list("brig");
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/east{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -59899,6 +59919,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -60690,6 +60714,8 @@
 "wPu" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -62197,9 +62223,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "xNa" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/grimy,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "xNc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -62654,6 +62679,9 @@
 "yaJ" = (
 /obj/structure/chair{
 	name = "Defendant"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
@@ -88901,8 +88929,8 @@ tcz
 uHO
 uca
 tcz
-tcz
-fUX
+hei
+kDW
 wYB
 pVZ
 mOD
@@ -89158,7 +89186,7 @@ kFq
 kFq
 kFq
 kFq
-kFq
+gua
 wdv
 wYB
 xLC
@@ -89416,7 +89444,7 @@ aiX
 aiX
 aiX
 wYB
-wYB
+hns
 wYB
 gmK
 wYB
@@ -89674,8 +89702,8 @@ vRY
 aiX
 mPd
 hGW
-jXI
-adu
+tSc
+uOe
 wYB
 jQz
 ldD
@@ -89932,7 +89960,7 @@ aiX
 cyP
 xNa
 adu
-adu
+uOe
 wYB
 waZ
 ldD
@@ -90444,7 +90472,7 @@ agj
 agj
 aiX
 cBy
-tSc
+xNa
 adu
 nQB
 wYB
@@ -90700,7 +90728,7 @@ vad
 nJO
 kUI
 aiX
-cyP
+rch
 huh
 adu
 nGc
@@ -96353,7 +96381,7 @@ hfM
 aaU
 xHD
 anF
-mUK
+fUX
 ajm
 miY
 ajp
@@ -96607,7 +96635,7 @@ kxi
 viO
 mwk
 oOI
-aGH
+csZ
 nas
 gOB
 aiA
@@ -97626,8 +97654,8 @@ rQN
 afA
 aiX
 aiX
-rch
-hei
+aiX
+aiX
 vvi
 pOR
 anc
@@ -97886,7 +97914,7 @@ aiX
 aiX
 aiX
 aiX
-gua
+aiX
 aiX
 aiX
 aiX
@@ -98143,7 +98171,7 @@ sUX
 arq
 mEU
 nfa
-csZ
+rQR
 fPr
 sJx
 cJf
@@ -98400,7 +98428,7 @@ sUX
 arq
 hgK
 blD
-csZ
+rQR
 gBW
 faG
 ckA
@@ -98657,7 +98685,7 @@ sUX
 arq
 aMp
 bSp
-csZ
+rQR
 qwT
 iPm
 jyz
@@ -98914,7 +98942,7 @@ sUX
 arq
 sNu
 pCU
-hns
+rQR
 hQC
 rzf
 dch


### PR DESCRIPTION
## О Pull Request
hh beep bip

ПР вносит следующие изменения:

Обновление интерьера: 

> офис АВД, зал суда, бар, санитарные помещения, фитнес-зона, коридор между фитнес-зоной и санитарными комнатами, кабинет мима и клоуна, гражданская гидропоника и изолятор.

Другие изменения: 

> Коридор между санитарными помещениями и крио незначительно расширен.
> Офис АВД уменьшен для увеличения площади зала суда.
> Пространство гражданской гидропоники было слегка сокращено.
> Добавлен переходной коридор между офисом НТР, бригом и камерой суда.
> Скорректированы несколько дверей с стандартными названиями шлюзов и названиями "s."
> Добавлены недостающие доступа для нескольких дверей внутри брига.

<details>
<summary>Основные различия</summary>

[NEW

![NEW](https://github.com/user-attachments/assets/054336c3-5d46-4a83-884e-6d21fb62d723)

[OLD

![OLD](https://github.com/user-attachments/assets/e5c8c7ae-7134-4684-803d-21a854abe59f)

</details>

<details>
<summary>Гидропоника и изолятор</summary>

[NEW

![HYDRO_NEW](https://github.com/user-attachments/assets/28114640-eed3-41a1-adb5-21f1b350ef7e)
[OLD

![HYDRO_OLD](https://github.com/user-attachments/assets/ded53921-cf27-40fc-bfb0-f9ecee227935)
[NEW

![ISO_NEW](https://github.com/user-attachments/assets/87b0717a-592e-42d6-bbf6-ee31180154b8)
[OLD

![ISO_OLD](https://github.com/user-attachments/assets/9105b681-c49d-415b-93a0-11be492ac10c)

</details>

closes #4969 

## Changelog
:cl: Smol42
map: did a slight NSS Journey / Box Station remap.
/:cl:
