### PR TITLE
Поднимаем урон ТГ антагов (в поисках идеала в баладе о крысопушках)

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -13,7 +13,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 28 //Fluffy edit, original 20
+	force = 28 // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 20
 	throwforce = 10
 	wound_bonus = 5
 	bare_wound_bonus = 15
@@ -219,7 +219,7 @@
 	name = "\improper cursed blade"
 	desc = "A dark blade, cursed to bleed forever. In constant struggle between the eldritch and the dark, it is forced to accept any wielder as its master. \
 		Its eye's cornea drips blood endlessly into the ground, yet its piercing gaze remains on you."
-	force = 32 //Fluffy edit, original 25
+	force = 32 // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 25
 	throwforce = 15
 	block_chance = 35
 	wound_bonus = 25

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -13,7 +13,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 20
+	force = 28 //Fluffy edit, original 20
 	throwforce = 10
 	wound_bonus = 5
 	bare_wound_bonus = 15
@@ -219,7 +219,7 @@
 	name = "\improper cursed blade"
 	desc = "A dark blade, cursed to bleed forever. In constant struggle between the eldritch and the dark, it is forced to accept any wielder as its master. \
 		Its eye's cornea drips blood endlessly into the ground, yet its piercing gaze remains on you."
-	force = 25
+	force = 32 //Fluffy edit, original 25
 	throwforce = 15
 	block_chance = 35
 	wound_bonus = 25

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -178,7 +178,7 @@
 	wound_type = /datum/wound/slash/flesh/critical
 	research_tree_icon_path = 'icons/ui_icons/antags/heretic/knowledge.dmi'
 	research_tree_icon_state = "blade_upgrade_lock"
-	var/chance = 55 //Fluffy edit, original 35
+	var/chance = 55 // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 35
 
 /datum/heretic_knowledge/blade_upgrade/flesh/lock/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	if(prob(chance))

--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -178,7 +178,7 @@
 	wound_type = /datum/wound/slash/flesh/critical
 	research_tree_icon_path = 'icons/ui_icons/antags/heretic/knowledge.dmi'
 	research_tree_icon_state = "blade_upgrade_lock"
-	var/chance = 35
+	var/chance = 55 //Fluffy edit, original 35
 
 /datum/heretic_knowledge/blade_upgrade/flesh/lock/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	if(prob(chance))

--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -47,7 +47,7 @@
 		var/obj/item/bodypart/bodypart = pick(victim.bodyparts)
 		var/datum/wound/slash/flesh/crit_wound = new wound_type()
 		crit_wound.apply_wound(bodypart)
-		victim.apply_damage(30, BURN, wound_bonus = CANT_WOUND) //Fluffy edit, original 20
+		victim.apply_damage(30, BURN, wound_bonus = CANT_WOUND) // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 20
 
 		new /obj/effect/temp_visual/cleave(get_turf(victim))
 

--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -47,7 +47,7 @@
 		var/obj/item/bodypart/bodypart = pick(victim.bodyparts)
 		var/datum/wound/slash/flesh/crit_wound = new wound_type()
 		crit_wound.apply_wound(bodypart)
-		victim.apply_damage(20, BURN, wound_bonus = CANT_WOUND)
+		victim.apply_damage(30, BURN, wound_bonus = CANT_WOUND) //Fluffy edit, original 20
 
 		new /obj/effect/temp_visual/cleave(get_turf(victim))
 

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -40,8 +40,8 @@
 	)
 
 	var/mob/living/living_owner = owner
-	cast_on.adjustBruteLoss(25) //Fluffy edit, original 20
-	living_owner.adjustBruteLoss(-25) //Fluffy edit, original 20
+	cast_on.adjustBruteLoss(25) // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 20
+	living_owner.adjustBruteLoss(-25) // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 20
 
 	if(!cast_on.blood_volume || !living_owner.blood_volume)
 		return TRUE

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -40,8 +40,8 @@
 	)
 
 	var/mob/living/living_owner = owner
-	cast_on.adjustBruteLoss(20)
-	living_owner.adjustBruteLoss(-20)
+	cast_on.adjustBruteLoss(25) //Fluffy edit, original 20
+	living_owner.adjustBruteLoss(-25) //Fluffy edit, original 20
 
 	if(!cast_on.blood_volume || !living_owner.blood_volume)
 		return TRUE

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -101,7 +101,7 @@
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "dio_knife"
 	speed = 2
-	damage = 25
+	damage = 35 //Fluffy edit, original 25
 	armour_penetration = 100
 	sharpness = SHARP_EDGED
 	wound_bonus = 15

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -101,7 +101,7 @@
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "dio_knife"
 	speed = 2
-	damage = 35 //Fluffy edit, original 25
+	damage = 35 // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 25
 	armour_penetration = 100
 	sharpness = SHARP_EDGED
 	wound_bonus = 15

--- a/code/modules/antagonists/heretic/magic/mind_gate.dm
+++ b/code/modules/antagonists/heretic/magic/mind_gate.dm
@@ -32,7 +32,7 @@
 		return FALSE
 
 	cast_on.adjust_confusion(10 SECONDS)
-	cast_on.adjustOxyLoss(30)
+	cast_on.adjustOxyLoss(40) //Fluffy edit. original 30
 	cast_on.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/body), "Mind gate, cast by [owner]")
 	cast_on.cause_hallucination(/datum/hallucination/delusion/preset/heretic/gate, "Caused by mindgate")
 	cast_on.adjustOrganLoss(ORGAN_SLOT_BRAIN, 30)

--- a/code/modules/antagonists/heretic/magic/mind_gate.dm
+++ b/code/modules/antagonists/heretic/magic/mind_gate.dm
@@ -32,7 +32,7 @@
 		return FALSE
 
 	cast_on.adjust_confusion(10 SECONDS)
-	cast_on.adjustOxyLoss(40) //Fluffy edit. original 30
+	cast_on.adjustOxyLoss(40) // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 30
 	cast_on.cause_hallucination(get_random_valid_hallucination_subtype(/datum/hallucination/body), "Mind gate, cast by [owner]")
 	cast_on.cause_hallucination(/datum/hallucination/delusion/preset/heretic/gate, "Caused by mindgate")
 	cast_on.adjustOrganLoss(ORGAN_SLOT_BRAIN, 30)

--- a/code/modules/antagonists/heretic/magic/void_phase.dm
+++ b/code/modules/antagonists/heretic/magic/void_phase.dm
@@ -56,7 +56,7 @@
 			continue
 		if(living_mob.can_block_magic(antimagic_flags))
 			continue
-		living_mob.apply_damage(60, BRUTE, wound_bonus = CANT_WOUND) //Fluffy edit, original 40
+		living_mob.apply_damage(60, BRUTE, wound_bonus = CANT_WOUND) // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 40
 		living_mob.apply_status_effect(/datum/status_effect/void_chill, 1)
 
 /obj/effect/temp_visual/voidin

--- a/code/modules/antagonists/heretic/magic/void_phase.dm
+++ b/code/modules/antagonists/heretic/magic/void_phase.dm
@@ -56,7 +56,7 @@
 			continue
 		if(living_mob.can_block_magic(antimagic_flags))
 			continue
-		living_mob.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND)
+		living_mob.apply_damage(60, BRUTE, wound_bonus = CANT_WOUND) //Fluffy edit, original 40
 		living_mob.apply_status_effect(/datum/status_effect/void_chill, 1)
 
 /obj/effect/temp_visual/voidin

--- a/code/modules/antagonists/heretic/magic/void_pull.dm
+++ b/code/modules/antagonists/heretic/magic/void_pull.dm
@@ -31,7 +31,7 @@
 
 	// Before we cast the actual effects, deal AOE damage to anyone adjacent to us
 	for(var/mob/living/nearby_living as anything in get_things_to_cast_on(cast_on, damage_radius))
-		nearby_living.apply_damage(30, BRUTE, wound_bonus = CANT_WOUND)
+		nearby_living.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND) //Fluffy edit, original 30
 		nearby_living.apply_status_effect(/datum/status_effect/void_chill, 1)
 
 /datum/action/cooldown/spell/aoe/void_pull/get_things_to_cast_on(atom/center, radius_override = 1)

--- a/code/modules/antagonists/heretic/magic/void_pull.dm
+++ b/code/modules/antagonists/heretic/magic/void_pull.dm
@@ -31,7 +31,7 @@
 
 	// Before we cast the actual effects, deal AOE damage to anyone adjacent to us
 	for(var/mob/living/nearby_living as anything in get_things_to_cast_on(cast_on, damage_radius))
-		nearby_living.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND) //Fluffy edit, original 30
+		nearby_living.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND) // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 30
 		nearby_living.apply_status_effect(/datum/status_effect/void_chill, 1)
 
 /datum/action/cooldown/spell/aoe/void_pull/get_things_to_cast_on(atom/center, radius_override = 1)

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -79,7 +79,7 @@
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.adjustStaminaLoss(17 * repetitions) // first one = 30 stam //Fluffy edit, original 6
+		carbon_owner.adjustStaminaLoss(17 * repetitions) // first one = 30 stam // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 6
 		carbon_owner.adjustFireLoss(3 * repetitions) // first one = 15 burn
 		for(var/mob/living/carbon/victim in shuffle(range(1, carbon_owner)))
 			if(IS_HERETIC(victim) || victim == carbon_owner)

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -79,7 +79,7 @@
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.adjustStaminaLoss(17 * repetitions) // first one = 30 stam // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 6
+		carbon_owner.adjustStaminaLoss(17 * repetitions) // first one = 85 stam; FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 6
 		carbon_owner.adjustFireLoss(3 * repetitions) // first one = 15 burn
 		for(var/mob/living/carbon/victim in shuffle(range(1, carbon_owner)))
 			if(IS_HERETIC(victim) || victim == carbon_owner)

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -79,7 +79,7 @@
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
-		carbon_owner.adjustStaminaLoss(6 * repetitions) // first one = 30 stam
+		carbon_owner.adjustStaminaLoss(17 * repetitions) // first one = 30 stam //Fluffy edit, original 6
 		carbon_owner.adjustFireLoss(3 * repetitions) // first one = 15 burn
 		for(var/mob/living/carbon/victim in shuffle(range(1, carbon_owner)))
 			if(IS_HERETIC(victim) || victim == carbon_owner)

--- a/code/modules/antagonists/nightmare/nightmare_equipment.dm
+++ b/code/modules/antagonists/nightmare/nightmare_equipment.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/weapons/changeling_items.dmi'
 	icon_state = "arm_blade"
 	inhand_icon_state = "arm_blade"
-	force = 30 //Fluffy edit, original 25
+	force = 30 // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 25
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'

--- a/code/modules/antagonists/nightmare/nightmare_equipment.dm
+++ b/code/modules/antagonists/nightmare/nightmare_equipment.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/weapons/changeling_items.dmi'
 	icon_state = "arm_blade"
 	inhand_icon_state = "arm_blade"
-	force = 25
+	force = 30 //Fluffy edit, original 25
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'

--- a/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/weapons/voidwalker_items.dmi'
 	icon_state = "tentacle"
 	inhand_icon_state = "tentacle"
-	force = 25
+	force = 35 //Fluffy edit, original 25
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/voidwalker_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/voidwalker_righthand.dmi'

--- a/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/weapons/voidwalker_items.dmi'
 	icon_state = "tentacle"
 	inhand_icon_state = "tentacle"
-	force = 35 //Fluffy edit, original 25
+	force = 35 // FLUFFY FRONTIER EDIT: ANTAG BUFF #5159; original: 25
 	armour_penetration = 35
 	lefthand_file = 'icons/mob/inhands/antag/voidwalker_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/voidwalker_righthand.dmi'


### PR DESCRIPTION
## О Pull Request
Урон еретических серпов поднимаем с 20 до 28, проклятого серпа с 25 до 32
Поднимаем урон многих боевых заклинаний еретика на 10-15
Еретик пепла теперь кидает в стаминакрит при ударе по метке как и должен
Поднимаем урон light eater с 25 до 30
Поднимаем максимальный урон void eater с 25 до 35
Путь ключа имеет больше шанс вызвать критический кровоток
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
"Крысопушки имба" и так далее, как одно из возможных решений поднятие статов у обязательных антаг вещей с ТГ.
## Доказательства тестирования
Пару измененных циферок, не столь сложно
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
:cl:
balance: Damage buffs for herethic, void walker and nightmare items or spells
/:cl:
