### PR TITLE
Удаление возможности  врат, и н-спекта сканировать на контрабанду.

### DIFF
--- a/code/game/machinery/scanner_gate.dm
+++ b/code/game/machinery/scanner_gate.dm
@@ -5,7 +5,6 @@
 #define SCANGATE_WANTED "Wanted"
 #define SCANGATE_SPECIES "Species"
 #define SCANGATE_NUTRITION "Nutrition"
-#define SCANGATE_CONTRABAND "Contraband"
 #define SCANGATE_GENDER "Gender" // NOVA EDIT ADDITION
 
 /obj/machinery/scanner_gate
@@ -40,8 +39,6 @@
 	var/minus_false_beep = 0
 	///Base false positive/negative chance
 	var/base_false_beep = 5
-	///Is an n-spect scanner attached to the gate? Enables contraband scanning.
-	var/obj/item/inspector/n_spect = null
 	///List of species that can be scanned by the gate. Supports adding more species' IDs during in-game.
 	var/list/available_species = list(
 		SPECIES_HUMAN,
@@ -79,12 +76,6 @@
 	for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
 		minus_false_beep = scanning_module.tier //The better are scanninning modules - the lower is chance of False Positives
 
-/obj/machinery/scanner_gate/atom_deconstruct(disassembled)
-	. = ..()
-	if(n_spect)
-		n_spect.forceMove(drop_location())
-		n_spect = null
-
 /obj/machinery/scanner_gate/examine(mob/user)
 	. = ..()
 
@@ -93,18 +84,6 @@
 		. += span_notice("The control panel is ID-locked. Swipe a valid ID to unlock it.")
 	else
 		. += span_notice("The control panel is unlocked. Swipe an ID to lock it.")
-	if(n_spect)
-		. += span_notice("The scanner is equipped with an N-Spect scanner. Use a [span_boldnotice("crowbar")] to uninstall.")
-
-/obj/machinery/scanner_gate/add_context(atom/source, list/context, obj/item/held_item, mob/user)
-	. = ..()
-	if(n_spect && held_item?.tool_behaviour == TOOL_CROWBAR)
-		context[SCREENTIP_CONTEXT_LMB] = "Remove N-Spect scanner"
-		return CONTEXTUAL_SCREENTIP_SET
-	if(!n_spect && istype(held_item, /obj/item/inspector))
-		context[SCREENTIP_CONTEXT_LMB] = "Install N-Spect scanner"
-		return CONTEXTUAL_SCREENTIP_SET
-
 
 /obj/machinery/scanner_gate/proc/on_entered(datum/source, atom/movable/thing)
 	SIGNAL_HANDLER
@@ -139,19 +118,6 @@
 		return
 	set_scanline("passive")
 
-/obj/machinery/scanner_gate/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
-	if(istype(tool, /obj/item/inspector))
-		if(n_spect)
-			to_chat(user, span_warning("The scanner is already equipped with an N-Spect scanner."))
-			return ITEM_INTERACT_BLOCKING
-		else
-			to_chat(user, span_notice("You install an N-Spect scanner on [src]."))
-			n_spect = tool
-			if(!user.transferItemToLoc(tool, src))
-				return ITEM_INTERACT_BLOCKING
-			return ITEM_INTERACT_SUCCESS
-	return NONE
-
 /obj/machinery/scanner_gate/attackby(obj/item/attacking_item, mob/user, params)
 	var/obj/item/card/id/card = attacking_item.GetID()
 	if(card)
@@ -175,22 +141,6 @@
 	return ..()
 
 /obj/machinery/scanner_gate/crowbar_act(mob/living/user, obj/item/tool)
-	. = ..()
-	if(n_spect)
-		if(locked)
-			balloon_alert(user, "locked!")
-			return ITEM_INTERACT_BLOCKING
-
-		to_chat(user, span_notice("You uninstall [n_spect] from [src]."))
-		n_spect.forceMove(drop_location())
-		return ITEM_INTERACT_SUCCESS
-
-/obj/machinery/scanner_gate/Exited(atom/gone)
-	. = ..()
-	if(gone == n_spect)
-		n_spect = null
-		if(scangate_mode == SCANGATE_CONTRABAND)
-			scangate_mode = SCANGATE_NONE
 
 /obj/machinery/scanner_gate/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
@@ -280,15 +230,6 @@
 					if(scanned_human.gender == detect_gender)
 						beep = TRUE
 		//NOVA EDIT ADDITION END - MORE SCANNER GATE OPTIONS
-		if(SCANGATE_CONTRABAND)
-			for(var/obj/item/content in thing.get_all_contents_skipping_traits(TRAIT_CONTRABAND_BLOCKER))
-				detected_thing = "Contraband"
-				if(content.is_contraband())
-					beep = TRUE
-					break
-			if(!n_spect.scans_correctly)
-				beep = !beep //We do a little trolling
-
 	if(reverse)
 		beep = !beep
 
@@ -354,7 +295,6 @@
 	data["target_species_id"] = detect_species_id
 	data["target_nutrition"] = detect_nutrition
 	data["target_gender"] = detect_gender //NOVA EDIT - MORE SCANNER GATE OPTIONS
-	data["contraband_enabled"] = !!n_spect
 	data["target_zombie"] = (detect_species_id == SPECIES_ZOMBIE)
 	return data
 
@@ -426,5 +366,4 @@
 #undef SCANGATE_WANTED
 #undef SCANGATE_SPECIES
 #undef SCANGATE_NUTRITION
-#undef SCANGATE_CONTRABAND
 #undef SCANGATE_GENDER // NOVA EDIT ADDITION

--- a/code/game/objects/items/inspector.dm
+++ b/code/game/objects/items/inspector.dm
@@ -20,7 +20,6 @@
 	interaction_flags_click = NEED_DEXTERITY
 	throw_range = 1
 	throw_speed = 1
-	COOLDOWN_DECLARE(scanning_person) //Cooldown for scanning a carbon
 	///How long it takes to print on time each mode, ordered NORMAL, FAST, HONK
 	var/list/time_list = list(5 SECONDS, 1 SECONDS, 0.1 SECONDS)
 	///Which print time mode we're on.
@@ -109,16 +108,7 @@
 		return ITEM_INTERACT_BLOCKING
 
 	if(iscarbon(interacting_with)) //Prevents insta scanning people
-		if(!COOLDOWN_FINISHED(src, scanning_person))
-			return ITEM_INTERACT_BLOCKING
-
-		visible_message(span_warning("[user] starts scanning [interacting_with] with [src]"))
-		to_chat(interacting_with, span_userdanger("[user] is trying to scan you for contraband!"))
-		balloon_alert_to_viewers("scanning...")
-		playsound(src, SFX_INDUSTRIAL_SCAN, 20, TRUE, -2, TRUE, FALSE)
-		COOLDOWN_START(src, scanning_person, 4 SECONDS)
-		if(!do_after(user, 4 SECONDS, interacting_with))
-			return ITEM_INTERACT_BLOCKING
+		return
 
 	if(contraband_scan(interacting_with, user))
 		playsound(src, 'sound/machines/uplink/uplinkerror.ogg', 40)

--- a/tgui/packages/tgui/interfaces/ScannerGate.jsx
+++ b/tgui/packages/tgui/interfaces/ScannerGate.jsx
@@ -73,10 +73,6 @@ const SCANNER_GATE_ROUTES = {
     component: () => ScannerGateGender,
   },
   //  NOVA EDIT END - MORE SCANNER GATE OPTIONS
-  Contraband: {
-    title: 'Scanner Mode: Contraband',
-    component: () => ScannerGateContraband,
-  },
 };
 
 const ScannerGateControl = (props) => {
@@ -104,7 +100,6 @@ const ScannerGateControl = (props) => {
 
 const ScannerGateOff = (props) => {
   const { act, data } = useBackend();
-  const { contraband_enabled } = data;
   return (
     <>
       <Box mb={2}>Select a scanning mode below.</Box>
@@ -136,11 +131,6 @@ const ScannerGateOff = (props) => {
         <Button
           content="Nutrition"
           onClick={() => act('set_mode', { new_mode: 'Nutrition' })}
-        />
-        <Button
-          content="Contraband"
-          disabled={contraband_enabled ? false : true}
-          onClick={() => act('set_mode', { new_mode: 'Contraband' })}
         />
       </Box>
     </>
@@ -314,21 +304,6 @@ const ScannerGateGender = (props) => {
   );
 };
 //  NOVA EDIT END - MORE SCANNER GATE OPTIONS
-const ScannerGateContraband = (props) => {
-  const { data } = useBackend();
-  const { reverse } = data;
-  return (
-    <>
-      <Box mb={2}>
-        Trigger if the person scanned {reverse ? 'does not have' : 'has'} any
-        anything considered contraband. Requires an N-spect scanner installed to
-        enable.
-      </Box>
-      <ScannerGateMode />
-    </>
-  );
-};
-
 const ScannerGateMode = (props) => {
   const { act, data } = useBackend();
   const { reverse } = data;


### PR DESCRIPTION
Отзеркалочка ТГшного  ПРа  в связи с тем что на Нове  злоупотребление отсутствует и там он не нужен https://github.com/tgstation/tgstation/pull/87882
## О Pull Request
Удаляет у Н-спекта возможность сканировать людей на предмет контрабанды, и вешать его на ворота.
остальной функционал на месте. так же избавление от бага

>It's expressly not supposed to flag up storage implants. This sounds like a feature that was bugged that nobody reported as bugged.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Следуя стопам ТГ, отбирает у брига бинарный антагчек после которого геймплей в любом случае превращается в пятисекундную перестрелку.




</details>

## Changelog
:cl:
del: выпил забагованой, и заабуженой фишки
/:cl:
