### PR TITLE
Удаление сикей лока на предметы zanozkin

### DIFF
--- a/tff_modular/modules/~donator/loadout.dm
+++ b/tff_modular/modules/~donator/loadout.dm
@@ -16,87 +16,87 @@
 /datum/loadout_item/suit/teshari_furcoat
 	name = "Tenka Fabric Coat"
 	item_path= /obj/item/clothing/suit/teshari/furcoat
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/suit/teshari_labcoat
 	name = "Lab Coat"
 	item_path= /obj/item/clothing/suit/teshari/labcoat
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/suit/teshari_graycoat
 	name = "Grey Coat"
 	item_path= /obj/item/clothing/suit/teshari/graycoat
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/suit/teshari_jacket
 	name = "Black Jacket FZ"
 	item_path= /obj/item/clothing/suit/teshari/jacket
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/suit/teshari_jacket/noblue
 	name = "Black Jacket FZ"
 	item_path = /obj/item/clothing/suit/teshari/jacket/noblue
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/suit/teshari_russian_jacket
 	name = "Russian Raptor Coat"
 	item_path= /obj/item/clothing/suit/teshari/russian_jacket
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/suit/teshari_aqua_cloak // тут действительно в виде suit.
 	name = "Short Shirt FZ"
 	item_path= /obj/item/clothing/suit/teshari/aqua_cloak // тут действительно в виде suit.
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_consultant
 	name = "Crocs Suit"
 	item_path= /obj/item/clothing/under/teshari/consultant
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_consultant/female
 	name = "Crocs Skirt"
 	item_path= /obj/item/clothing/under/teshari/consultant/female
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_nt_combineso
 	name = "Combeniso NT"
 	item_path= /obj/item/clothing/under/teshari/nt_combineso
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_meme
 	name = "Shirt and Shorts"
 	item_path= /obj/item/clothing/under/teshari/meme
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_elite_suit
 	name = "Elite Feathered"
 	item_path= /obj/item/clothing/under/teshari/elite_suit
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_elite_suit/plus
 	name = "Elite Feathered+"
 	item_path= /obj/item/clothing/under/teshari/elite_suit/plus
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_waistcoat
 	name = "Delicate Suit"
 	item_path= /obj/item/clothing/under/teshari/waistcoat
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/under/miscellaneous/teshari_mechsuit
 	name = "Rivka"
 	item_path= /obj/item/clothing/under/teshari/mechsuit
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/neck/teshari_tenkacoat
 	name = "Small cloak"
 	item_path= /obj/item/clothing/neck/cloak/teshari/tenkacoat
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/toys/oktavia
 	name = "Oktavia"
 	item_path= /obj/item/toy/plush/oktavia
-	ckeywhitelist = list("zanozkin")
+	donator_only = TRUE
 
 /datum/loadout_item/toys/maru
 	name = "Maru Plushie"


### PR DESCRIPTION

## О Pull Request
Просто удаляет привязку к сикею. Вместо неё предметы теперь просто для донатеров. Потому что да.
## Changelog
:cl:
add: Several ckey locked cosmetic item are now unlocked for every donator
/:cl:
