### PR TITLE
Нерф телепортирования при помощи БС кристалов

### DIFF
--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -37,7 +37,7 @@
 	new /obj/effect/particle_effect/sparks(loc)
 	playsound(loc, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	blink_mob(user)
-	user.adjust_disgust(15) // FLUFFYFRONTIER BLUESPACE CRYSTAL NERF
+	user.adjust_disgust(15) // FLUFFY FRONTIER ADDITION: BLUESPACE CRYSTAL NERF 5301
 	use(1)
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/L)
@@ -50,8 +50,8 @@
 		new /obj/effect/particle_effect/sparks(T)
 		playsound(loc, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		if(isliving(hit_atom))
-			var/mob/living/our_living = hit_atom // FLUFFYFRONTIER BLUESPACE CRYSTAL NERF
-			our_living.adjust_disgust(15) // FLUFFYFRONTIER BLUESPACE CRYSTAL NERF
+			var/mob/living/our_living = hit_atom // FLUFFY FRONTIER ADDITION: BLUESPACE CRYSTAL NERF 5301
+			our_living.adjust_disgust(15) // FLUFFY FRONTIER ADDITION: BLUESPACE CRYSTAL NERF 5301
 			blink_mob(hit_atom)
 		use(1)
 

--- a/code/game/objects/items/stacks/bscrystal.dm
+++ b/code/game/objects/items/stacks/bscrystal.dm
@@ -37,6 +37,7 @@
 	new /obj/effect/particle_effect/sparks(loc)
 	playsound(loc, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	blink_mob(user)
+	user.adjust_disgust(15) // FLUFFYFRONTIER BLUESPACE CRYSTAL NERF
 	use(1)
 
 /obj/item/stack/ore/bluespace_crystal/proc/blink_mob(mob/living/L)
@@ -49,6 +50,8 @@
 		new /obj/effect/particle_effect/sparks(T)
 		playsound(loc, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 		if(isliving(hit_atom))
+			var/mob/living/our_living = hit_atom // FLUFFYFRONTIER BLUESPACE CRYSTAL NERF
+			our_living.adjust_disgust(15) // FLUFFYFRONTIER BLUESPACE CRYSTAL NERF
 			blink_mob(hit_atom)
 		use(1)
 


### PR DESCRIPTION

## О Pull Request
Теперь телепортирование на БС кристалах будет накидывать 15 отвращения за каждое применение, для понимания 50 отвращения дает шанс начать блевать, муддебаф и экран начинает крутить. Ну и да, меня попросили перекинуть этот ПР сюда.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Меньше антагов на миллионе БС кристалов уху!!
## Доказательства тестирования
Я проверил, облевал все что можно!!
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
:cl:
balance: bluespace crystals now stack disgust on use
/:cl:
