### PR TITLE
Деактивация выбора побочек у триторов

### DIFF
--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -23,7 +23,7 @@
 	/// Whether this uplink handler has objectives.
 	var/has_objectives = TRUE
 	/// Whether this uplink handler can TAKE objectives.
-	var/can_take_objectives = FALSE  //FLUFFY FRONTIER EDIT no-more-pobochki ORIGINAL: TRUE
+	var/can_take_objectives = FALSE  //FLUFFY FRONTIER EDIT no-more-pobochki pull 5373 ORIGINAL: TRUE
 	/// The maximum number of objectives that can be taken
 	var/maximum_active_objectives = 2
 	/// The maximum number of potential objectives that can exist.

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -23,7 +23,7 @@
 	/// Whether this uplink handler has objectives.
 	var/has_objectives = TRUE
 	/// Whether this uplink handler can TAKE objectives.
-	var/can_take_objectives = TRUE
+	var/can_take_objectives = FALSE  //FLUFFY FRONTIER EDIT no-more-pobochki ORIGINAL: TRUE
 	/// The maximum number of objectives that can be taken
 	var/maximum_active_objectives = 2
 	/// The maximum number of potential objectives that can exist.


### PR DESCRIPTION

## О Pull Request
Отключаем возможность брать и выполнять побочки у триторов
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Тритор не будет превращаться в мажора по первому пику, побочки были одной из раковых опухолей
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
:cl:
balance: Traitors cannot take secondary objectives anymore
/:cl:
