### PR TITLE
Еще пара фиксов для ксеносов

### DIFF
--- a/tff_modular/modules/tgmc_xenos/code/base_nova_xeno.dm
+++ b/tff_modular/modules/tgmc_xenos/code/base_nova_xeno.dm
@@ -39,7 +39,6 @@
 
 /mob/living/carbon/alien/adult/tgmc/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/seethrough_mob)
 
 	if(next_evolution)
 		GRANT_ACTION(/datum/action/cooldown/alien/tgmc/generic_evolve)

--- a/tff_modular/modules/tgmc_xenos/code/base_nova_xeno.dm
+++ b/tff_modular/modules/tgmc_xenos/code/base_nova_xeno.dm
@@ -9,6 +9,17 @@
 	maptext_height = 64
 	maptext_width = 64
 	pressure_resistance = 200
+
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	)
+
 	/// What icon file update_held_items will look for when making inhands for xenos
 	var/alt_inhands_file = 'tff_modular/modules/tgmc_xenos/icons/big_xenos.dmi'
 	/// Setting this will give a xeno generic_evolve set to evolve them into this type
@@ -23,17 +34,8 @@
 	var/on_fire_pixel_x = 16
 	/// Pixel Y shifting of the on fire overlay
 	var/on_fire_pixel_y = 16
-
-	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
-		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
-	)
+	/// Все дополнительные органы, что должны находиться в телах ксеносов
+	var/list/additional_organ_types_by_slot
 
 /mob/living/carbon/alien/adult/tgmc/Initialize(mapload)
 	. = ..()
@@ -46,6 +48,11 @@
 
 	ADD_TRAIT(src, TRAIT_XENO_HEAL_AURA, TRAIT_XENO_INNATE)
 	real_name = "alien [caste]"
+
+/mob/living/carbon/alien/adult/tgmc/create_internal_organs()
+	if(additional_organ_types_by_slot)
+		default_organ_types_by_slot += additional_organ_types_by_slot
+	return ..()
 
 /// Called when a larva or xeno evolves, adds a configurable timer on evolving again to the xeno
 /mob/living/carbon/alien/adult/tgmc/proc/has_just_evolved()

--- a/tff_modular/modules/tgmc_xenos/code/base_nova_xeno.dm
+++ b/tff_modular/modules/tgmc_xenos/code/base_nova_xeno.dm
@@ -5,7 +5,6 @@
 	icon = 'tff_modular/modules/tgmc_xenos/icons/big_xenos.dmi'
 	rotate_on_lying = FALSE
 	base_pixel_x = -16 //All of the xeno sprites are 64x64, and we want them to be level with the tile they are on, much like oversized quirk users
-	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //above most mobs, but below speechbubbles
 	maptext_height = 64
 	maptext_width = 64
@@ -25,14 +24,23 @@
 	/// Pixel Y shifting of the on fire overlay
 	var/on_fire_pixel_y = 16
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
+	)
 
 /mob/living/carbon/alien/adult/tgmc/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/seethrough_mob)
 
-	GRANT_ACTION(/datum/action/cooldown/alien/nova/sleepytime)
 	if(next_evolution)
-		GRANT_ACTION(/datum/action/cooldown/alien/nova/generic_evolve)
+		GRANT_ACTION(/datum/action/cooldown/alien/tgmc/generic_evolve)
 
 	pixel_x = -16
 
@@ -52,12 +60,12 @@
 		return
 	has_evolved_recently = FALSE
 
-/datum/action/cooldown/alien/nova
+/datum/action/cooldown/alien/tgmc
 	button_icon = 'tff_modular/modules/tgmc_xenos/icons/xeno_actions.dmi'
 	/// Some xeno abilities block other abilities from being used, this allows them to get around that in cases where it is needed
 	var/can_be_used_always = FALSE
 
-/datum/action/cooldown/alien/nova/IsAvailable(feedback = FALSE)
+/datum/action/cooldown/alien/tgmc/IsAvailable(feedback = FALSE)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -69,36 +77,21 @@
 	if(!istype(owner_alien) || owner_alien.unable_to_use_abilities)
 		return FALSE
 
-/datum/action/cooldown/alien/nova/sleepytime //I don't think this has a mechanical advantage but they have cool resting sprites so...
-	name = "Rest"
-	desc = "Sometimes even murder aliens need to have a little lie down."
-	button_icon_state = "sleepytime"
-
-/datum/action/cooldown/alien/nova/sleepytime/Activate()
-	var/mob/living/carbon/sleepytime_mob = owner
-	if(!isalien(owner))
-		return FALSE
-	if(!sleepytime_mob.resting)
-		sleepytime_mob.set_resting(new_resting = TRUE, silent = FALSE, instant = TRUE)
-		return TRUE
-	sleepytime_mob.set_resting(new_resting = FALSE, silent = FALSE, instant = FALSE)
-	return TRUE
-
-/datum/action/cooldown/alien/nova/generic_evolve
+/datum/action/cooldown/alien/tgmc/generic_evolve
 	name = "Evolve"
 	desc = "Allows us to evolve to a higher caste of our type, if there is not one already."
 	button_icon_state = "evolution"
 	/// What type this ability will turn the owner into upon completion
 	var/type_to_evolve_into
 
-/datum/action/cooldown/alien/nova/generic_evolve/Grant(mob/grant_to)
+/datum/action/cooldown/alien/tgmc/generic_evolve/Grant(mob/grant_to)
 	. = ..()
 	if(!isalien(owner))
 		return
 	var/mob/living/carbon/alien/target_alien = owner
 	plasma_cost = target_alien.get_max_plasma() //This ability should always require that a xeno be at their max plasma capacity to use
 
-/datum/action/cooldown/alien/nova/generic_evolve/Activate()
+/datum/action/cooldown/alien/tgmc/generic_evolve/Activate()
 	var/mob/living/carbon/alien/adult/tgmc/evolver = owner
 
 	if(!istype(evolver))

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/defender.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/defender.dm
@@ -12,7 +12,7 @@
 	melee_damage_upper = 30
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/warrior
 
-	default_organ_types_by_slot = list(
+	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small,
 	)
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/defender.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/defender.dm
@@ -7,14 +7,26 @@
 	maxHealth = 300
 	health = 300
 	icon_state = "aliendefender"
+	mob_size = MOB_SIZE_LARGE
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/warrior
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small,
+	)
+
 /mob/living/carbon/alien/adult/tgmc/defender/Initialize(mapload)
 	. = ..()
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep,
+		/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep,
 		/datum/action/cooldown/mob_cooldown/charge/basic_charge/defender,
 	)
 	grant_actions_by_list(innate_actions)
@@ -23,11 +35,7 @@
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_heavy)
 
-/mob/living/carbon/alien/adult/tgmc/defender/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small
-	..()
-
-/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep
+/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep
 	name = "Crushing Tail Sweep"
 	desc = "Throw back attackers with a sweep of your tail, likely breaking some bones in the process."
 
@@ -53,7 +61,7 @@
 	/// What type of damage should the tail sweep do
 	var/impact_damage_type = BRUTE
 
-/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep/IsAvailable(feedback = FALSE)
+/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/IsAvailable(feedback = FALSE)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -62,7 +70,7 @@
 	if(!istype(owner_alien) || owner_alien.unable_to_use_abilities)
 		return FALSE
 
-/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep/cast_on_thing_in_aoe(atom/movable/victim, atom/caster)
+/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/cast_on_thing_in_aoe(atom/movable/victim, atom/caster)
 	if(!isliving(victim))
 		return
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/defender.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/defender.dm
@@ -13,13 +13,6 @@
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/warrior
 
 	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small,
 	)
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/drone.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/drone.dm
@@ -11,14 +11,7 @@
 	melee_damage_upper = 20
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/praetorian
 
-	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
 		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
 		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/drone.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/drone.dm
@@ -11,16 +11,29 @@
 	melee_damage_upper = 20
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/praetorian
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+	)
+
 /mob/living/carbon/alien/adult/tgmc/drone/Initialize(mapload)
 	. = ..()
-	GRANT_ACTION(/datum/action/cooldown/alien/nova/heal_aura)
+	GRANT_ACTION(/datum/action/cooldown/alien/tgmc/heal_aura)
 
 /mob/living/carbon/alien/adult/tgmc/drone/create_internal_organs()
 	organs += new /obj/item/organ/alien/plasmavessel
 	organs += new /obj/item/organ/alien/resinspinner
 	..()
 
-/datum/action/cooldown/alien/nova/heal_aura
+/datum/action/cooldown/alien/tgmc/heal_aura
 	name = "Healing Aura"
 	desc = "Friendly xenomorphs in a short range around yourself will receive passive healing."
 	button_icon_state = "healaura"
@@ -39,7 +52,7 @@
 	/// The healing aura component itself that the ability uses
 	var/datum/component/aura_healing/aura_healing_component
 
-/datum/action/cooldown/alien/nova/heal_aura/Activate()
+/datum/action/cooldown/alien/tgmc/heal_aura/Activate()
 	. = ..()
 	if(aura_active)
 		owner.balloon_alert(owner, "already healing")
@@ -51,7 +64,7 @@
 	aura_healing_component = owner.AddComponent(/datum/component/aura_healing, range = aura_range, requires_visibility = TRUE, brute_heal = aura_healing_amount, burn_heal = aura_healing_amount, limit_to_trait = TRAIT_XENO_HEAL_AURA, healing_color = aura_healing_color)
 	return TRUE
 
-/datum/action/cooldown/alien/nova/heal_aura/proc/aura_deactivate()
+/datum/action/cooldown/alien/tgmc/heal_aura/proc/aura_deactivate()
 	if(!aura_active)
 		return
 	aura_active = FALSE

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/drone.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/drone.dm
@@ -28,11 +28,6 @@
 	. = ..()
 	GRANT_ACTION(/datum/action/cooldown/alien/tgmc/heal_aura)
 
-/mob/living/carbon/alien/adult/tgmc/drone/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	organs += new /obj/item/organ/alien/resinspinner
-	..()
-
 /datum/action/cooldown/alien/tgmc/heal_aura
 	name = "Healing Aura"
 	desc = "Friendly xenomorphs in a short range around yourself will receive passive healing."

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
@@ -7,15 +7,30 @@
 	maxHealth = 400
 	health = 400
 	icon_state = "alienpraetorian"
+	mob_size = MOB_SIZE_LARGE
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/queen
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/spitter,
+	)
+
 /mob/living/carbon/alien/adult/tgmc/praetorian/Initialize(mapload)
 	. = ..()
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/alien/nova/heal_aura/juiced,
-		/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep/hard_throwing,
+		/datum/action/cooldown/alien/tgmc/heal_aura/juiced,
+		/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/hard_throwing,
 	)
 	grant_actions_by_list(innate_actions)
 
@@ -23,13 +38,7 @@
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_big)
 
-/mob/living/carbon/alien/adult/tgmc/praetorian/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/large
-	organs += new /obj/item/organ/alien/neurotoxin/spitter
-	organs += new /obj/item/organ/alien/resinspinner
-	..()
-
-/datum/action/cooldown/alien/nova/heal_aura/juiced
+/datum/action/cooldown/alien/tgmc/heal_aura/juiced
 	name = "Strong Healing Aura"
 	desc = "Friendly xenomorphs in a longer range around yourself will receive passive healing."
 	button_icon_state = "healaura_juiced"
@@ -39,7 +48,7 @@
 	aura_healing_amount = 10
 	aura_healing_color = COLOR_RED_LIGHT
 
-/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep/hard_throwing
+/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/hard_throwing
 	name = "Flinging Tail Sweep"
 	desc = "Throw back attackers with a sweep of your tail that is much stronger than other aliens."
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
@@ -12,14 +12,7 @@
 	melee_damage_upper = 30
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/queen
 
-	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large,
 		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
 		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
@@ -67,7 +67,7 @@
 	icon = 'tff_modular/modules/tgmc_xenos/icons/xeno_actions.dmi'
 	icon_state = "throw_tail_anim"
 
-/datum/action/cooldown/alien/acid/nova/spread
+/datum/action/cooldown/alien/acid/tgmc/spread
 	name = "Spit Neurotoxin Spread"
 	desc = "Spits a spread neurotoxin at someone, exhausting them."
 	plasma_cost = 50
@@ -78,7 +78,7 @@
 
 /obj/item/ammo_casing/xenospit //This is probably really bad, however I couldn't find any other nice way to do this
 	name = "big glob of neurotoxin"
-	projectile_type = /obj/projectile/neurotoxin/nova/spitter_spread
+	projectile_type = /obj/projectile/neurotoxin/tgmc/spitter_spread
 	pellets = 3
 	variance = 20
 
@@ -94,7 +94,7 @@
 	icon_state = "neurotoxin"
 	damage = 25
 
-/datum/action/cooldown/alien/acid/nova/spread/lethal
+/datum/action/cooldown/alien/acid/tgmc/spread/lethal
 	name = "Spit Acid Spread"
 	desc = "Spits a spread of acid at someone, burning them."
 	acid_projectile = null
@@ -105,11 +105,11 @@
 
 /obj/item/ammo_casing/xenospit/spread/lethal
 	name = "big glob of acid"
-	projectile_type = /obj/projectile/neurotoxin/nova/acid/spitter_spread
+	projectile_type = /obj/projectile/neurotoxin/tgmc/acid/spitter_spread
 	pellets = 4
 	variance = 30
 
-/obj/projectile/neurotoxin/nova/acid/spitter_spread
+/obj/projectile/neurotoxin/tgmc/acid/spitter_spread
 	name = "acid spit"
 	icon_state = "toxin"
 	damage = 15
@@ -121,7 +121,7 @@
 	zone = BODY_ZONE_PRECISE_MOUTH
 	slot = ORGAN_SLOT_XENO_NEUROTOXINGLAND
 	actions_types = list(
-		/datum/action/cooldown/alien/acid/nova/spread,
-		/datum/action/cooldown/alien/acid/nova/spread/lethal,
+		/datum/action/cooldown/alien/acid/tgmc/spread,
+		/datum/action/cooldown/alien/acid/tgmc/spread/lethal,
 		/datum/action/cooldown/alien/acid/corrosion,
 	)

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/praetorian.dm
@@ -89,7 +89,7 @@
 /obj/item/ammo_casing/xenospit/tk_firing(mob/living/user, atom/fired_from)
 	return FALSE
 
-/obj/projectile/neurotoxin/nova/spitter_spread //Slightly nerfed because its a shotgun spread of these
+/obj/projectile/neurotoxin/tgmc/spitter_spread //Slightly nerfed because its a shotgun spread of these
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
 	damage = 25

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
@@ -21,6 +21,8 @@
 
 /mob/living/carbon/alien/adult/tgmc/queen/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/seethrough_mob)	// Люркеров у нас нету (слава богу), но выдать такую штуку кому-то хочется... Будет у королевы, как на обычном ТГ
+
 	var/static/list/innate_actions = list(
 		/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/hard_throwing,
 		/datum/action/cooldown/alien/tgmc/queen_screech,
@@ -88,3 +90,6 @@
 
 /mob/living/carbon/alien/adult/tgmc/proc/remove_shriekwave()
 	remove_overlay(HALO_LAYER)
+
+/mob/living/carbon/alien/adult/tgmc/queen/findQueen()
+	return	// Королева и так знает свое местоположение

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
@@ -47,8 +47,8 @@
 	zone = BODY_ZONE_PRECISE_MOUTH
 	slot = ORGAN_SLOT_XENO_NEUROTOXINGLAND
 	actions_types = list(
-		/datum/action/cooldown/alien/acid/nova,
-		/datum/action/cooldown/alien/acid/nova/lethal,
+		/datum/action/cooldown/alien/acid/tgmc,
+		/datum/action/cooldown/alien/acid/tgmc/lethal,
 		/datum/action/cooldown/alien/acid/corrosion,
 	)
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
@@ -11,14 +11,7 @@
 	melee_damage_lower = 30
 	melee_damage_upper = 35
 
-	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large/queen,
 		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
 		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/queen.dm
@@ -7,27 +7,36 @@
 	maxHealth = 500
 	health = 500
 	icon_state = "alienqueen"
+	mob_size = MOB_SIZE_LARGE
 	melee_damage_lower = 30
 	melee_damage_upper = 35
+
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/large/queen,
+		ORGAN_SLOT_XENO_RESINSPINNER = /obj/item/organ/alien/resinspinner,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/queen,
+		ORGAN_SLOT_XENO_EGGSAC = /obj/item/organ/alien/eggsac/tgmc,
+	)
 
 /mob/living/carbon/alien/adult/tgmc/queen/Initialize(mapload)
 	. = ..()
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep/hard_throwing,
-		/datum/action/cooldown/alien/nova/queen_screech,
+		/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/hard_throwing,
+		/datum/action/cooldown/alien/tgmc/queen_screech,
 	)
 	grant_actions_by_list(innate_actions)
 
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_big)
-
-/mob/living/carbon/alien/adult/tgmc/queen/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/large/queen
-	organs += new /obj/item/organ/alien/resinspinner
-	organs += new /obj/item/organ/alien/neurotoxin/queen
-	organs += new /obj/item/organ/alien/eggsac/tgmc
-	..()
 
 /mob/living/carbon/alien/adult/tgmc/queen/alien_talk(message, shown_name = name)
 	..(message, shown_name, TRUE)
@@ -58,13 +67,13 @@
 
 	return ..()
 
-/datum/action/cooldown/alien/nova/queen_screech
+/datum/action/cooldown/alien/tgmc/queen_screech
 	name = "Deafening Screech"
 	desc = "Let out a screech so deafeningly loud that anything with the ability to hear around you will likely be incapacitated for a short time."
 	button_icon_state = "screech"
 	cooldown_time = 5 MINUTES
 
-/datum/action/cooldown/alien/nova/queen_screech/Activate()
+/datum/action/cooldown/alien/tgmc/queen_screech/Activate()
 	. = ..()
 	var/mob/living/carbon/alien/adult/tgmc/queenie = owner
 	playsound(queenie, 'tff_modular/modules/tgmc_xenos/sound/alien_queen_screech.ogg', 100, FALSE, 8, 0.9)

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/ravager.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/ravager.dm
@@ -9,23 +9,20 @@
 	maxHealth = 350
 	health = 350
 	icon_state = "alienravager"
+	mob_size = MOB_SIZE_LARGE
 	melee_damage_lower = 30
 	melee_damage_upper = 35
 
 /mob/living/carbon/alien/adult/tgmc/ravager/Initialize(mapload)
 	. = ..()
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep/slicing,
-		/datum/action/cooldown/alien/nova/literally_too_angry_to_die,
+		/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/slicing,
+		/datum/action/cooldown/alien/tgmc/literally_too_angry_to_die,
 		/datum/action/cooldown/mob_cooldown/charge/triple_charge/ravager,
 	)
 	grant_actions_by_list(innate_actions)
 
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-
-/mob/living/carbon/alien/adult/tgmc/ravager/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	..()
 
 /datum/action/cooldown/mob_cooldown/charge/triple_charge/ravager
 	name = "Triple Charge Attack"
@@ -47,7 +44,7 @@
 	. = ..()
 	return TRUE
 
-/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep/slicing
+/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep/slicing
 	name = "Slicing Tail Sweep"
 	desc = "Throw back attackers with a swipe of your tail, slicing them with its sharpened tip."
 
@@ -67,7 +64,7 @@
 	icon = 'tff_modular/modules/tgmc_xenos/icons/xeno_actions.dmi'
 	icon_state = "slice_tail_anim"
 
-/datum/action/cooldown/alien/nova/literally_too_angry_to_die
+/datum/action/cooldown/alien/tgmc/literally_too_angry_to_die
 	name = "Endure"
 	desc = "Imbue your body with unimaginable amounts of rage (and plasma) to allow yourself to ignore all pain for a short time."
 	button_icon_state = "literally_too_angry"
@@ -77,7 +74,7 @@
 	/// How long the endure ability should last when activated
 	var/endure_duration = 20 SECONDS
 
-/datum/action/cooldown/alien/nova/literally_too_angry_to_die/Activate()
+/datum/action/cooldown/alien/tgmc/literally_too_angry_to_die/Activate()
 	. = ..()
 	if(endure_active)
 		owner.balloon_alert(owner, "already enduring")
@@ -93,7 +90,7 @@
 	endure_active = TRUE
 	return TRUE
 
-/datum/action/cooldown/alien/nova/literally_too_angry_to_die/proc/endure_deactivate()
+/datum/action/cooldown/alien/tgmc/literally_too_angry_to_die/proc/endure_deactivate()
 	endure_active = FALSE
 	owner.balloon_alert(owner, "endure ended")
 	owner.remove_filter(RAVAGER_OUTLINE_EFFECT)

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/ravager.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/ravager.dm
@@ -13,6 +13,10 @@
 	melee_damage_lower = 30
 	melee_damage_upper = 35
 
+	additional_organ_types_by_slot = list(
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel
+	)
+
 /mob/living/carbon/alien/adult/tgmc/ravager/Initialize(mapload)
 	. = ..()
 	var/static/list/innate_actions = list(

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/rouny.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/rouny.dm
@@ -11,11 +11,22 @@
 	health = 150
 	icon_state = "alienrunner"
 	/// Holds the evade ability to be granted to the runner later
-	var/datum/action/cooldown/alien/nova/evade/evade_ability
+	var/datum/action/cooldown/alien/tgmc/evade/evade_ability
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/ravager
 	on_fire_pixel_y = 0
+
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = 	/obj/item/organ/alien/plasmavessel/small/tiny,
+	)
 
 /mob/living/carbon/alien/adult/tgmc/runner/Initialize(mapload)
 	. = ..()
@@ -25,11 +36,7 @@
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_quick)
 
-/mob/living/carbon/alien/adult/tgmc/runner/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small/tiny
-	..()
-
-/datum/action/cooldown/alien/nova/evade
+/datum/action/cooldown/alien/tgmc/evade
 	name = "Evade"
 	desc = "Allows you to evade any projectile that would hit you for a few seconds."
 	button_icon_state = "evade"
@@ -40,7 +47,7 @@
 	/// How long evasion should last
 	var/evasion_duration = 10 SECONDS
 
-/datum/action/cooldown/alien/nova/evade/Activate()
+/datum/action/cooldown/alien/tgmc/evade/Activate()
 	. = ..()
 	if(evade_active) //Can't evade while we're already evading.
 		owner.balloon_alert(owner, "already evading")
@@ -58,17 +65,17 @@
 	return TRUE
 
 /// Handles deactivation of the xeno evasion ability, mainly unregistering the signal and giving a balloon alert
-/datum/action/cooldown/alien/nova/evade/proc/evasion_deactivate()
+/datum/action/cooldown/alien/tgmc/evade/proc/evasion_deactivate()
 	evade_active = FALSE
 	owner.balloon_alert(owner, "evasion ended")
 	UnregisterSignal(owner, COMSIG_PROJECTILE_ON_HIT)
 
-/datum/action/cooldown/alien/nova/evade/proc/give_back_ventcrawl()
+/datum/action/cooldown/alien/tgmc/evade/proc/give_back_ventcrawl()
 	ADD_TRAIT(owner, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 	to_chat(owner, span_notice("We are rested enough to crawl through vents again."))
 
 /// Handles if either BULLET_ACT_HIT or BULLET_ACT_FORCE_PIERCE happens to something using the xeno evade ability
-/datum/action/cooldown/alien/nova/evade/proc/on_projectile_hit()
+/datum/action/cooldown/alien/tgmc/evade/proc/on_projectile_hit()
 	if(owner.build_incapacitated(INCAPABLE_GRAB) || !isturf(owner.loc) || !evade_active)
 		return BULLET_ACT_HIT
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/rouny.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/rouny.dm
@@ -17,14 +17,7 @@
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/ravager
 	on_fire_pixel_y = 0
 
-	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small/tiny,
 	)
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/rouny.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/rouny.dm
@@ -25,7 +25,7 @@
 		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
 		ORGAN_SLOT_EARS = /obj/item/organ/ears,
 		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
-		ORGAN_SLOT_XENO_PLASMAVESSEL = 	/obj/item/organ/alien/plasmavessel/small/tiny,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel/small/tiny,
 	)
 
 /mob/living/carbon/alien/adult/tgmc/runner/Initialize(mapload)

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/sentinel.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/sentinel.dm
@@ -11,15 +11,23 @@
 	melee_damage_upper = 15
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/spitter
 
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/sentinel,
+	)
+
 /mob/living/carbon/alien/adult/tgmc/sentinel/Initialize(mapload)
 	. = ..()
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_slow)
-
-/mob/living/carbon/alien/adult/tgmc/sentinel/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel/small
-	organs += new /obj/item/organ/alien/neurotoxin/sentinel
-	..()
 
 /datum/action/cooldown/alien/acid/nova
 	name = "Spit Neurotoxin"

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/sentinel.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/sentinel.dm
@@ -11,14 +11,7 @@
 	melee_damage_upper = 15
 	next_evolution = /mob/living/carbon/alien/adult/tgmc/spitter
 
-	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
 		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
 		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/sentinel,

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/sentinel.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/sentinel.dm
@@ -29,14 +29,14 @@
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_slow)
 
-/datum/action/cooldown/alien/acid/nova
+/datum/action/cooldown/alien/acid/tgmc
 	name = "Spit Neurotoxin"
 	desc = "Spits neurotoxin at someone, exhausting them."
 	button_icon = 'tff_modular/modules/tgmc_xenos/icons/xeno_actions.dmi'
 	button_icon_state = "neurospit_0"
 	plasma_cost = 40
 	/// A singular projectile? Use this one and leave acid_casing null
-	var/acid_projectile = /obj/projectile/neurotoxin/nova
+	var/acid_projectile = /obj/projectile/neurotoxin/tgmc
 	/// You want it to be more like a shotgun style attack? Use this one and make acid_projectile null
 	var/acid_casing
 	/// Used in to_chat messages to the owner
@@ -48,10 +48,10 @@
 	shared_cooldown = MOB_SHARED_COOLDOWN_3
 	cooldown_time = 5 SECONDS
 
-/datum/action/cooldown/alien/acid/nova/IsAvailable(feedback = FALSE)
+/datum/action/cooldown/alien/acid/tgmc/IsAvailable(feedback = FALSE)
 	return ..() && isturf(owner.loc)
 
-/datum/action/cooldown/alien/acid/nova/set_click_ability(mob/on_who)
+/datum/action/cooldown/alien/acid/tgmc/set_click_ability(mob/on_who)
 	. = ..()
 	if(!.)
 		return
@@ -62,7 +62,7 @@
 	build_all_button_icons()
 	on_who.update_icons()
 
-/datum/action/cooldown/alien/acid/nova/unset_click_ability(mob/on_who, refund_cooldown = TRUE)
+/datum/action/cooldown/alien/acid/tgmc/unset_click_ability(mob/on_who, refund_cooldown = TRUE)
 	. = ..()
 	if(!.)
 		return
@@ -74,7 +74,7 @@
 	build_all_button_icons()
 	on_who.update_icons()
 
-/datum/action/cooldown/alien/acid/nova/InterceptClickOn(mob/living/clicker, params, atom/target)
+/datum/action/cooldown/alien/acid/tgmc/InterceptClickOn(mob/living/clicker, params, atom/target)
 	. = ..()
 	if(!.)
 		unset_click_ability(clicker, refund_cooldown = FALSE)
@@ -109,10 +109,10 @@
 
 	CRASH("Neither acid_projectile or acid_casing are set on [clicker]'s spit attack!")
 
-/datum/action/cooldown/alien/acid/nova/Activate(atom/target)
+/datum/action/cooldown/alien/acid/tgmc/Activate(atom/target)
 	return TRUE
 
-/obj/projectile/neurotoxin/nova
+/obj/projectile/neurotoxin/tgmc
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
 	damage = 30
@@ -125,15 +125,15 @@
 		damage = 0
 	return ..()
 
-/datum/action/cooldown/alien/acid/nova/lethal
+/datum/action/cooldown/alien/acid/tgmc/lethal
 	name = "Spit Acid"
 	desc = "Spits neurotoxin at someone, burning them."
-	acid_projectile = /obj/projectile/neurotoxin/nova/acid
+	acid_projectile = /obj/projectile/neurotoxin/tgmc/acid
 	button_icon_state = "acidspit_0"
 	projectile_name = "acid"
 	button_base_icon = "acidspit"
 
-/obj/projectile/neurotoxin/nova/acid
+/obj/projectile/neurotoxin/tgmc/acid
 	name = "acid spit"
 	icon_state = "toxin"
 	damage = 20
@@ -146,6 +146,6 @@
 	zone = BODY_ZONE_PRECISE_MOUTH
 	slot = ORGAN_SLOT_XENO_NEUROTOXINGLAND
 	actions_types = list(
-		/datum/action/cooldown/alien/acid/nova,
-		/datum/action/cooldown/alien/acid/nova/lethal,
+		/datum/action/cooldown/alien/acid/tgmc,
+		/datum/action/cooldown/alien/acid/tgmc/lethal,
 	)

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/spitter.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/spitter.dm
@@ -7,8 +7,22 @@
 	maxHealth = 300
 	health = 300
 	icon_state = "alienspitter"
+	mob_size = MOB_SIZE_LARGE
 	melee_damage_lower = 15
 	melee_damage_upper = 20
+
+	default_organ_types_by_slot = list(
+		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
+		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
+		ORGAN_SLOT_EARS = /obj/item/organ/ears,
+		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
+		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
+		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/spitter,
+	)
 
 /mob/living/carbon/alien/adult/tgmc/spitter/Initialize(mapload)
 	. = ..()
@@ -16,8 +30,3 @@
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_heavy)
 
 	REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
-
-/mob/living/carbon/alien/adult/tgmc/spitter/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	organs += new /obj/item/organ/alien/neurotoxin/spitter
-	..()

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/spitter.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/spitter.dm
@@ -11,14 +11,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 
-	default_organ_types_by_slot = list(
-		ORGAN_SLOT_BRAIN = /obj/item/organ/brain/alien,
-		ORGAN_SLOT_XENO_HIVENODE = /obj/item/organ/alien/hivenode,
-		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/alien,
-		ORGAN_SLOT_EYES = /obj/item/organ/eyes/alien,
-		ORGAN_SLOT_LIVER = /obj/item/organ/liver/alien,
-		ORGAN_SLOT_EARS = /obj/item/organ/ears,
-		ORGAN_SLOT_STOMACH = /obj/item/organ/stomach/alien,
+	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
 		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
 		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/spitter,

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/spitter.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/spitter.dm
@@ -13,7 +13,6 @@
 
 	additional_organ_types_by_slot = list(
 		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel,
-		ORGAN_SLOT_XENO_ACIDGLAND = /obj/item/organ/alien/acid,
 		ORGAN_SLOT_XENO_NEUROTOXINGLAND = /obj/item/organ/alien/neurotoxin/spitter,
 	)
 

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/warrior.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/warrior.dm
@@ -11,6 +11,10 @@
 	melee_damage_lower = 30
 	melee_damage_upper = 35
 
+	additional_organ_types_by_slot = list(
+		ORGAN_SLOT_XENO_PLASMAVESSEL = /obj/item/organ/alien/plasmavessel
+	)
+
 /mob/living/carbon/alien/adult/tgmc/warrior/Initialize(mapload)
 	. = ..()
 	var/static/list/innate_actions = list(

--- a/tff_modular/modules/tgmc_xenos/code/xeno_types/warrior.dm
+++ b/tff_modular/modules/tgmc_xenos/code/xeno_types/warrior.dm
@@ -7,15 +7,16 @@
 	maxHealth = 400
 	health = 400
 	icon_state = "alienwarrior"
+	mob_size = MOB_SIZE_LARGE
 	melee_damage_lower = 30
 	melee_damage_upper = 35
 
 /mob/living/carbon/alien/adult/tgmc/warrior/Initialize(mapload)
 	. = ..()
 	var/static/list/innate_actions = list(
-		/datum/action/cooldown/spell/aoe/repulse/xeno/nova_tailsweep,
+		/datum/action/cooldown/spell/aoe/repulse/xeno/tgmc_tailsweep,
 		/datum/action/cooldown/mob_cooldown/charge/basic_charge/defender,
-		/datum/action/cooldown/alien/nova/warrior_agility,
+		/datum/action/cooldown/alien/tgmc/warrior_agility,
 	)
 	grant_actions_by_list(innate_actions)
 
@@ -23,11 +24,7 @@
 
 	add_movespeed_modifier(/datum/movespeed_modifier/alien_big)
 
-/mob/living/carbon/alien/adult/tgmc/warrior/create_internal_organs()
-	organs += new /obj/item/organ/alien/plasmavessel
-	..()
-
-/datum/action/cooldown/alien/nova/warrior_agility
+/datum/action/cooldown/alien/tgmc/warrior_agility
 	name = "Agility Mode"
 	desc = "Drop onto all fours, increasing your speed at the cost of damage and being unable to use most abilities."
 	button_icon_state = "the_speed_is_alot"
@@ -36,7 +33,7 @@
 	/// Is the warrior currently running around on all fours?
 	var/being_agile = FALSE
 
-/datum/action/cooldown/alien/nova/warrior_agility/Activate()
+/datum/action/cooldown/alien/tgmc/warrior_agility/Activate()
 	. = ..()
 	if(!being_agile)
 		begin_agility()
@@ -46,7 +43,7 @@
 		return TRUE
 
 /// Handles the visual indication and code activation of the warrior agility ability (say that five times fast)
-/datum/action/cooldown/alien/nova/warrior_agility/proc/begin_agility()
+/datum/action/cooldown/alien/tgmc/warrior_agility/proc/begin_agility()
 	var/mob/living/carbon/alien/adult/tgmc/agility_target = owner
 	agility_target.balloon_alert(agility_target, "agility active")
 	to_chat(agility_target, span_danger("We drop onto all fours, allowing us to move at much greater speed at expense of being able to use most abilities."))
@@ -61,7 +58,7 @@
 	agility_target.melee_damage_upper = 20
 
 /// Handles the visual indicators and code side of deactivating the agility ability
-/datum/action/cooldown/alien/nova/warrior_agility/proc/end_agility()
+/datum/action/cooldown/alien/tgmc/warrior_agility/proc/end_agility()
 	var/mob/living/carbon/alien/adult/tgmc/agility_target = owner
 	agility_target.balloon_alert(agility_target, "agility ended")
 	playsound(agility_target, 'tff_modular/modules/tgmc_xenos/sound/alien_roar2.ogg', 100, TRUE, 8, 0.9) //Warrior runs up on all fours, stands upright, screams at you


### PR DESCRIPTION
## О Pull Request

Исправляет баг из-за которого некоторые ксеносы не могли строить и создавать резину.
Так же были убраны последние следы новы: например `/datum/action/cooldown/alien/acid/nova` стал `/datum/action/cooldown/alien/acid/tgmc` и т.д.
Убрано бесполезная кнопкая для Rest (непонятно, зачем нужно 3-я кнопка для этого действия, если для него есть кнопка снизу справа и верб в статпанели).
И было небольшое изменение баланса (которое никто не заметит, ведь этих ксеносов еще не трогали): невидимость у всех ксеносов, кроме королевы, была убрана.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Исправление бага.
Изменение способности становиться невидимым связана с тем, что эти ксеносы и так достаточно сильные. А если еще и дать им всем возможность быть люркером (которого у нас, к счастью, нет) - это уже слишком. Королеве оставлено по двум причинам: королева слабая в одиночку и у ванильных тг ксеносов только королева может становиться невидимой.
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

Дрон
![image](https://github.com/user-attachments/assets/a21692c8-0f85-47ac-9348-1c228390175b)

Преторианец
![image](https://github.com/user-attachments/assets/177aef8a-0a54-4348-a065-01f897afcc54)

Королева
![image](https://github.com/user-attachments/assets/06872d4f-de4a-49dd-92ed-108cccfa9064)

</details>

## Changelog
:cl:
fix: tgmc alien drones will now be able to build their alien stuff out of rubber.
code: any mention of novasector has been removed from all paths related to tgmc xenos.
balance: all tgmc xenos, except the queen, can no longer become invisible.
/:cl:
