### PR TITLE
bye bye skild

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -101,9 +101,11 @@
 	item_type = /obj/item/gun/ballistic/automatic/pistol/type207
 	cost = PAYCHECK_COMMAND * 4
 
+/* FLUFFY FRONTIER REMOVAL
 /datum/armament_entry/company_import/sol_defense/sidearm/skild
 	item_type = /obj/item/gun/ballistic/automatic/pistol/trappiste
 	cost = PAYCHECK_COMMAND * 6
+*/
 
 /datum/armament_entry/company_import/sol_defense/sidearm/takbok
 	item_type = /obj/item/gun/ballistic/revolver/takbok

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -107,9 +107,11 @@
 	cost = PAYCHECK_COMMAND * 6
 */
 
+/* FLUFFY FRONTIER REMOVAL
 /datum/armament_entry/company_import/sol_defense/sidearm/takbok
 	item_type = /obj/item/gun/ballistic/revolver/takbok
 	cost = PAYCHECK_COMMAND * 6
+*/
 
 // Lethal anything that's not a pistol, requires high company interest
 


### PR DESCRIPTION
## О Pull Request

Убирает Скильд и Такбок из карго, оставляя его только у НТРа как табельное.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

По заказу Яжрета. Револьвер, ебущее живое и неживое, ломающее постройки и имеющее 40 дамага за выстрел. Тот самый револьвер, который как основное оружие у некоторых ОБР, ЦКшников и Армадайна, в свободном владении как табельное оружие закупается СБшниками каждый раунд. Теперь этого не будет.

## Доказательства тестирования

-

## Changelog
:cl:
balance: После несчастного случая с покушением на лейтенанта ЦК со стороны инженера с применением крупнокалиберного револьвера Скильд, НаноТрейзен принял решение наложить вето на поставку образцов вооружения данного калибра (Défonce и Défenestreur)на территории научных станций во избежании дальнейших покушений на высокопоставленных лиц из-за невозможности регулировать оборот высоколетального оружия, что считается табельным.
/:cl:
