### PR TITLE
Бульдог, ЦР привязаны к прогрессии, выпилены дубликаты у нюкопс, лоноп аплинков

### DIFF
--- a/tff_modular/modules/uplink_item/code/categories/ammuniton.dm
+++ b/tff_modular/modules/uplink_item/code/categories/ammuniton.dm
@@ -55,7 +55,7 @@
 	limited_stock = 1
 	cost = 4
 	item = /obj/item/ammo_box/magazine/m12g/meteor
-
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
 
 /datum/uplink_item/ammo/shotgun/slug_traitor
 	name = "12g Slug Drum"

--- a/tff_modular/modules/uplink_item/code/categories/dangerous.dm
+++ b/tff_modular/modules/uplink_item/code/categories/dangerous.dm
@@ -31,7 +31,8 @@
 			24-round magazine and is compatible with suppressors."
 	item = /obj/item/gun/ballistic/automatic/c20r/unrestricted
 	cost = 12
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS
+	progression_minimum = 30 MINUTES
 
 /datum/uplink_item/dangerous/shotgun_traitor
 	name = "Bulldog Shotgun"
@@ -39,4 +40,5 @@
 			quarter anti-personnel engagements."
 	item = /obj/item/gun/ballistic/shotgun/bulldog/unrestricted
 	cost = 12
-	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	progression_minimum = 50 MINUTES
+	purchasable_from = ~UPLINK_ALL_SYNDIE_OPS


### PR DESCRIPTION

Бульдог, ЦР привязаны к прогрессии, выпилены дубликаты у нюкопс, лоноп аплинков
## О Pull Request
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
:cl:
balance: удалены дубликаты из аплинков, Ц20Р привязан к прогрессии 30 минут, Бульдог привязан к прогрессии 45 минут

/:cl:
