### PR TITLE
Zashch returns

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
@@ -112,9 +112,9 @@
 	item_type = /obj/item/gun/ballistic/revolver/shotgun_revolver
 	cost = PAYCHECK_COMMAND * 6
 
-/* /datum/armament_entry/company_import/nri_surplus/firearm/zashch
+/datum/armament_entry/company_import/nri_surplus/firearm/zashch
 	item_type = /obj/item/gun/ballistic/automatic/pistol/zashch
-	cost = PAYCHECK_COMMAND * 6 */ // FLUFFY FRONTIER REMOVAL - NRI WEAPONS REBALANCE
+	cost = PAYCHECK_COMMAND * 6
 
 /datum/armament_entry/company_import/nri_surplus/firearm/plasma_thrower
 	item_type = /obj/item/gun/ballistic/automatic/pistol/plasma_thrower


### PR DESCRIPTION

## О Pull Request

Возвращение Защитника в карго.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Теперь это тактическое оружие и регламентируется согласно нему.

## Доказательства тестирования

![изображение](https://github.com/user-attachments/assets/f20cc172-641a-4d6f-bd21-bbbbfef30d7e)

## Changelog
:cl:
balance: Защитник вернулся в поставки и снаряжение СБ в качестве тактического оружия, что не даёт его свободно заказывать и применять в Зелёный Код.
/:cl:
