### PR TITLE
Fixed sol rifle and Zashch ammo

### DIFF
--- a/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/nri_military_surplus.dm
@@ -159,8 +159,8 @@
 	subcategory = "Firearm Magazines"
 	cost = PAYCHECK_CREW
 
-/* /datum/armament_entry/company_import/nri_surplus/firearm_ammo/zashch
-	item_type = /obj/item/ammo_box/magazine/zashch/spawns_empty */ // FLUFFY FRONTIER REMOVAL - NRI WEAPONS REBALANCE
+/datum/armament_entry/company_import/nri_surplus/firearm_ammo/zashch
+	item_type = /obj/item/ammo_box/magazine/zashch/spawns_empty
 
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/plasma_battery
 	item_type = /obj/item/ammo_box/magazine/recharge/plasma_battery

--- a/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
+++ b/modular_nova/modules/company_imports/code/armament_datums/sol_defense.dm
@@ -145,10 +145,10 @@
 	cost = PAYCHECK_COMMAND * 10
 	restricted = TRUE
 
-/* /datum/armament_entry/company_import/sol_defense/longarm/infanterie
+/datum/armament_entry/company_import/sol_defense/longarm/infanterie
 	item_type = /obj/item/gun/ballistic/automatic/sol_rifle
 	cost = PAYCHECK_COMMAND * 14
-	restricted = TRUE */ // FLUFFY FRONTIER REMOVAL - SOL WEAPONS REBALANCE
+	restricted = TRUE
 
 /* /datum/armament_entry/company_import/sol_defense/longarm/outomaties
 	item_type = /obj/item/gun/ballistic/automatic/sol_rifle/machinegun

--- a/modular_nova/modules/sec_haul/code/guns/armory_spawns.dm
+++ b/modular_nova/modules/sec_haul/code/guns/armory_spawns.dm
@@ -93,7 +93,6 @@
 	guns = list(
 		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
 		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
-		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano, // FLUFFY FRONTIER EDIT
-		// /obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle, // FLUFFY FRONTIER EDIT
-		// /obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle, // FLUFFY FRONTIER EDIT
+		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle,
+		/obj/item/storage/toolbox/guncase/nova/carwo_large_case/sol_rifle,
 	)


### PR DESCRIPTION

## О Pull Request

Возвращает магазин к Защеку

Восстанавливает штурмовую винтовку к покупке

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Актуализация с вики

## Доказательства тестирования

-

## Changelog
:cl:
balance: Магазины к Защитнику наконец тоже доступны в карго.
balance: Штурмовая винтовка Сола возвращена как вариант тактического оружия и восстановлена к заказу через карго.
/:cl:
