### PR TITLE
[МОДУЛЬНО] Нёрф/ребаланс еретического зелья прохождения сквозь стены.

### DIFF
--- a/tff_modular/modules/crucible_soul_potion_rebalance/crucible_soul_tweak.dm
+++ b/tff_modular/modules/crucible_soul_potion_rebalance/crucible_soul_tweak.dm
@@ -3,7 +3,7 @@
 	desc = "Your body and soul need some time to regain stability. During that time you will not be able to consume the brew of the crucible soul."
 	icon_state = "crucible"
 
-/datum/status_effect/crucible_soul_cooldown_effect
+/datum/status_effect/crucible_soul_cooldown
 	id = "Curse of Crucible Soul"
 	status_type = STATUS_EFFECT_REFRESH
 	duration = 300 SECONDS
@@ -11,11 +11,15 @@
 	show_duration = TRUE
 
 /obj/item/eldritch_potion/crucible_soul/attack_self(mob/user)
-	if(user.has_status_effect(/datum/status_effect/crucible_soul_cooldown_effect))
+	if(user.has_status_effect(/datum/status_effect/crucible_soul))
+		to_chat(user, span_alert("You are unable to consume the potion because you still are under it's effect!"))
+		return
+
+	if(user.has_status_effect(/datum/status_effect/crucible_soul_cooldown))
 		to_chat(user, span_alert("You are unable to consume the potion because your soul and body aren't ready yet!"))
 		return
 	. = ..()
 
 /datum/status_effect/crucible_soul/on_remove()
 	. = ..()
-	owner.apply_status_effect(/datum/status_effect/crucible_soul_cooldown_effect)
+	owner.apply_status_effect(/datum/status_effect/crucible_soul_cooldown)

--- a/tff_modular/modules/crucible_soul_potion_rebalance/crucible_soul_tweak.dm
+++ b/tff_modular/modules/crucible_soul_potion_rebalance/crucible_soul_tweak.dm
@@ -1,0 +1,21 @@
+/atom/movable/screen/alert/status_effect/crucible_soul_cooldown
+	name = "Curse of Crucible Soul"
+	desc = "Your body and soul need some time to regain stability. During that time you will not be able to consume the brew of the crucible soul."
+	icon_state = "crucible"
+
+/datum/status_effect/crucible_soul_cooldown_effect
+	id = "Curse of Crucible Soul"
+	status_type = STATUS_EFFECT_REFRESH
+	duration = 300 SECONDS
+	alert_type = /atom/movable/screen/alert/status_effect/crucible_soul_cooldown
+	show_duration = TRUE
+
+/obj/item/eldritch_potion/crucible_soul/attack_self(mob/user)
+	if(user.has_status_effect(/datum/status_effect/crucible_soul_cooldown_effect))
+		to_chat(user, span_alert("You are unable to consume the potion because your soul and body aren't ready yet!"))
+		return
+	. = ..()
+
+/datum/status_effect/crucible_soul/on_remove()
+	. = ..()
+	owner.apply_status_effect(/datum/status_effect/crucible_soul_cooldown_effect)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8990,6 +8990,7 @@
 #include "tff_modular\modules\cqd_holsters\code\holster_injections.dm"
 #include "tff_modular\modules\cqd_holsters\code\holster_storage.dm"
 #include "tff_modular\modules\cqd_holsters\code\utility.dm"
+#include "tff_modular\modules\crucible_soul_potion_rebalance\crucible_soul_tweak.dm"
 #include "tff_modular\modules\custom_huds\code\huds.dm"
 #include "tff_modular\modules\custom_objectives\code\custom_objectives.dm"
 #include "tff_modular\modules\custom_revolution\code\rev_convert_item.dm"


### PR DESCRIPTION
## О Pull Request

Данный ПР добавляет эффект "воздержания", который применяется по окончанию эффекта зелья "ноуклипа". Этот эффект запрещает использовать это зелье на протяжении 300 секунд (5 минут).

Сверху этот ПР запретит продлевать эффект зелья, пока он работает.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

ПР превратит это зелье из абузного в утилитарное, которое еретик будет использовать для того, чтобы достать спрятанную цель или врага, не позволяя бесконечно находиться в бесплотной форме.

## Доказательства тестирования



<details>
<summary>Скриншоты/Видео</summary>

![dreamseeker_SV1SJZmdaV](https://github.com/user-attachments/assets/7e72f4ee-dfe1-45b2-bfaa-83cb12f4a035)

![dreamseeker_1mCzEUs1nX](https://github.com/user-attachments/assets/d9c9723c-0f61-4533-ad4d-ff159e44653d)

![dreamseeker_AoEfili77J](https://github.com/user-attachments/assets/d8a4a1ca-543f-46af-b50f-fd0dadb2bf67)


</details>

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть конкретно замечены игроками или администраторами, вы должны добавить changelog. Если ваше изменение НЕ соответствует этому описанию, удалите этот раздел. Сами строки ченджлога должны быть строго на английском. -->

:cl:
balance: Brew of the crucible soul (еретическое зелье для прохождения сквозь стены) теперь по окончанию эффекта накладывает эффект "воздержания" на 5 минут, который не позволяет его употреблять.
balance: Brew of the crucible soul (еретическое зелье для прохождения сквозь стены) теперь нельзя выпить, если ты уже под эффектом этого зелья.
/:cl:
