### PR TITLE
Возможность отключить для игроков кнопку Observe в лобби 

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -70,6 +70,15 @@
 		ready = PLAYER_NOT_READY
 		return FALSE
 
+	// FLUFFT FRONTIER ADDITION START - toggle_observing
+	if(!GLOB.observing_allowed)
+		if(!check_rights(R_ADMIN))
+			alert(usr, "Observing is currently disabled!", "Observe")
+			return FALSE
+		if(alert(usr, "Observing is currently disabled,\n do you want to use your permissions to circumvent it?", "Observe", "Yes", "No") != "Yes")
+			return FALSE
+	// FLUFFT FRONTIER ADDITION END
+
 	var/less_input_message
 	if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP])
 		less_input_message = " - Notice: Observer freelook is currently disabled."

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -75,7 +75,7 @@
 		if(!check_rights(R_ADMIN))
 			alert(usr, "Observing is currently disabled!", "Observe")
 			return FALSE
-		if(alert(usr, "Observing is currently disabled,\n do you want to use your permissions to circumvent it?", "Observe", "Yes", "No") != "Yes")
+		if(alert(usr, "Observing is currently disabled, do you want\nto use your permissions to circumvent it?", "Observe", "Yes", "No") != "Yes")
 			return FALSE
 	// FLUFFT FRONTIER ADDITION END
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -72,7 +72,7 @@
 
 	// FLUFFT FRONTIER ADDITION START - toggle_observing
 	if(!GLOB.observing_allowed)
-		if(!check_rights(R_ADMIN))
+		if(!check_rights(R_ADMIN, FALSE))
 			alert(usr, "Observing is currently disabled!", "Observe")
 			return FALSE
 		if(alert(usr, "Observing is currently disabled, do you want\nto use your permissions to circumvent it?", "Observe", "Yes", "No") != "Yes")

--- a/tff_modular/modules/observing/observing.dm
+++ b/tff_modular/modules/observing/observing.dm
@@ -1,0 +1,29 @@
+GLOBAL_VAR_INIT(observing_allowed, TRUE)
+
+ADMIN_VERB(toggle_observing, R_ADMIN, "Toggle Observing", "Toggle the Observing in lobby menu.", ADMIN_CATEGORY_SERVER)
+	toggle_observing()
+	log_admin("[key_name(user)] toggled Observing.")
+	message_admins("[key_name_admin(user)] toggled Observing.")
+
+/proc/toggle_observing(toggle = null)
+	if(toggle != null)
+		if(toggle != GLOB.observing_allowed)
+			GLOB.observing_allowed = toggle
+		else
+			return
+	else
+		GLOB.observing_allowed = !GLOB.observing_allowed
+	to_chat(world, "<span class='oocplain'><B>The Observing has been globally [GLOB.observing_allowed ? "enabled" : "disabled"].</B></span>")
+
+// Трейт котоырй можно выдать заранее на следующий раунд, чтобы шустрые госты не успели нажать Observe до того, как админы выключат его
+/datum/station_trait/disabled_observing
+	name = "!Disable Observing"
+	weight = 0
+
+/datum/station_trait/disabled_observing/New()
+	. = ..()
+	toggle_observing(FALSE)
+
+/datum/station_trait/disabled_observing/Destroy()
+	. = ..()
+	toggle_observing(TRUE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9058,6 +9058,7 @@
 #include "tff_modular\modules\nanotrasen_consultant\area_spawn_entries.dm"
 #include "tff_modular\modules\nanotrasen_consultant\code.dm"
 #include "tff_modular\modules\nanotrasen_consultant\console_ntr.dm"
+#include "tff_modular\modules\observing\observing.dm"
 #include "tff_modular\modules\opposing_force\code.dm"
 #include "tff_modular\modules\police_nt\code\modsuit.dm"
 #include "tff_modular\modules\police_nt\code\nt_police.dm"


### PR DESCRIPTION
## О Pull Request

Просто добавляет верб для переключения возможности Observe-иться. Админы и ивентологи могут обойти это. Так же добавляет "станционный трейт", который автоматически отключает Observe. Трейт не раундомный, его можно выдать только педально кнопками
Повторюсь, вне ивентов это НИКАК не появляет на людей. Абсолютно.
Literally 1984.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

 Нам очень надо иногда для ивентов это... На игроков в самих раундах никак не влияет
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

![image](https://github.com/user-attachments/assets/d95c9396-d21d-4786-b1e1-d23c7a231514)

![image](https://github.com/user-attachments/assets/c8da662b-6b49-4dd1-8036-39a4b420db4f)

![image](https://github.com/user-attachments/assets/84db1fb4-0f09-44a2-9daa-d783efcd9950)

![image](https://github.com/user-attachments/assets/a4fff1f8-b712-49ce-a641-fbb247134a3b)

Для педалек
![image](https://github.com/user-attachments/assets/c28a4409-c786-41fb-b5a0-28d991a320bd)

</details>

## Changelog
:cl:
admin: Now Admins can disable the Observe button in the lobby for players
/:cl:
