### PR TITLE
Руссификация префиксов чата + микрофикс

### DIFF
--- a/tgui/packages/tgui-say/516/TguiSay.tsx
+++ b/tgui/packages/tgui-say/516/TguiSay.tsx
@@ -143,7 +143,7 @@ export function TguiSay() {
   function handleInput(event: FormEvent<HTMLTextAreaElement>): void {
     const iterator = channelIterator.current;
     let newValue = event.currentTarget.value;
-
+    console.log(event.currentTarget.value);
     let newPrefix = getPrefix(newValue) || currentPrefix;
     // Handles switching prefixes
     if (newPrefix && newPrefix !== currentPrefix) {

--- a/tgui/packages/tgui-say/516/TguiSay.tsx
+++ b/tgui/packages/tgui-say/516/TguiSay.tsx
@@ -143,7 +143,7 @@ export function TguiSay() {
   function handleInput(event: FormEvent<HTMLTextAreaElement>): void {
     const iterator = channelIterator.current;
     let newValue = event.currentTarget.value;
-    console.log(event.currentTarget.value);
+
     let newPrefix = getPrefix(newValue) || currentPrefix;
     // Handles switching prefixes
     if (newPrefix && newPrefix !== currentPrefix) {

--- a/tgui/packages/tgui-say/516/constants.ts
+++ b/tgui/packages/tgui-say/516/constants.ts
@@ -39,3 +39,27 @@ export const RADIO_PREFIXES = {
   ':l ': 'SolFed',
   // NOVA EDIT ADDITION END
 } as const;
+
+// TFF EDIT ADDITION START
+export const RUS_PREFIXES = {
+  ':ф ': ':a ',
+  ':и ': ':b ',
+  ':с ': ':c ',
+  ':у ': ':e ',
+  ':п ': ':g ',
+  ':ь ': ':m ',
+  ':т ': ':n ',
+  ':щ ': ':o ',
+  ':з ': ':p ',
+  ':ы ': ':s ',
+  ':е ': ':t ',
+  ':г ': ':u ',
+  ':м ': ':v ',
+  ':н ': ':y ',
+  ':ц ': ':w ',
+  ':л ': ':k ',
+  ':й ': ':q ',
+  ':ш ': ':i ',
+  ':д ': ':l ',
+} as const;
+// TFF EDIT ADDITION END

--- a/tgui/packages/tgui-say/516/helpers.ts
+++ b/tgui/packages/tgui-say/516/helpers.ts
@@ -1,5 +1,5 @@
 import { Channel } from '../ChannelIterator';
-import { RADIO_PREFIXES, WindowSize } from './constants';
+import { RADIO_PREFIXES, RUS_PREFIXES, WindowSize } from './constants'; // TFF EDIT
 
 /**
  * Once byond signals this via keystroke, it
@@ -45,7 +45,7 @@ function setWindowVisibility(visible: boolean): void {
   });
 }
 
-const CHANNEL_REGEX = /^[:.]\w\s/;
+const CHANNEL_REGEX = /^[:.][A-z0-9ЁёА-я]\s/; // TFF. ORIGINAL - /^[:.]\w\s/
 
 /** Tests for a channel prefix, returning it or none */
 export function getPrefix(
@@ -55,14 +55,18 @@ export function getPrefix(
     return;
   }
 
-  let adjusted = value
-    .slice(0, 3)
-    ?.toLowerCase()
-    ?.replace('.', ':') as keyof typeof RADIO_PREFIXES;
+  // TFF EDIT START. ORIGINAL:
+  /* let adjusted = value
+  .slice(0, 3)
+  ?.toLowerCase()
+  ?.replace('.', ':') as keyof typeof RADIO_PREFIXES;*/
 
+  let adjusted = value.slice(0)?.toLowerCase().replace('.', ':');
+  adjusted = RUS_PREFIXES[adjusted] ?? adjusted;
+  // TFF EDIT END
   if (!RADIO_PREFIXES[adjusted]) {
     return;
   }
 
-  return adjusted;
+  return adjusted as keyof typeof RADIO_PREFIXES; // TFF EDIT. ORIGINAL - return adjusted
 }

--- a/tgui/packages/tgui-say/516/helpers.ts
+++ b/tgui/packages/tgui-say/516/helpers.ts
@@ -45,7 +45,7 @@ function setWindowVisibility(visible: boolean): void {
   });
 }
 
-const CHANNEL_REGEX = /^[:.][A-z0-9ЁёА-я]\s/; // TFF. ORIGINAL - /^[:.]\w\s/
+const CHANNEL_REGEX = /^[:.][A-z0-9ЁёА-я]\s/; // TFF EDIT. ORIGINAL - /^[:.]\w\s/
 
 /** Tests for a channel prefix, returning it or none */
 export function getPrefix(
@@ -59,8 +59,8 @@ export function getPrefix(
   /* let adjusted = value
   .slice(0, 3)
   ?.toLowerCase()
-  ?.replace('.', ':') as keyof typeof RADIO_PREFIXES;*/
-
+  ?.replace('.', ':') as keyof typeof RADIO_PREFIXES;
+  */
   let adjusted = value.slice(0)?.toLowerCase().replace('.', ':');
   adjusted = RUS_PREFIXES[adjusted] ?? adjusted;
   // TFF EDIT END

--- a/tgui/packages/tgui-say/516/styles/colors.scss
+++ b/tgui/packages/tgui-say/516/styles/colors.scss
@@ -37,6 +37,8 @@ $_channel_map: (
   'Whis': hsl(238, 55%, 67%),
   'Do': hsl(137, 64%, 60%),
   // NOVA EDIT ADDITION END
+  // TFF EDIT - Eventmaker
+  'Event': hsl(92, 80%, 37%),
 );
 
 $channel_keys: map.keys($_channel_map) !default;

--- a/tgui/packages/tgui-say/516/styles/colors.scss
+++ b/tgui/packages/tgui-say/516/styles/colors.scss
@@ -37,8 +37,9 @@ $_channel_map: (
   'Whis': hsl(238, 55%, 67%),
   'Do': hsl(137, 64%, 60%),
   // NOVA EDIT ADDITION END
-  // TFF EDIT - Eventmaker
+  // TFF EDIT ADDITION START- Eventmaker
   'Event': hsl(92, 80%, 37%),
+  // TFF EDIT ADDITION END
 );
 
 $channel_keys: map.keys($_channel_map) !default;


### PR DESCRIPTION
## О Pull Request
Руссифицирует все префиксы чата. Даже ранее нерабочие алиумские, генокрадские и ТД. Теперь обработка идёт на фронте. Так же пофикшен недостающий стиль канала ивентеров (не тестил, лень)
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

![dreamseeker_6tFy3XweBa](https://github.com/user-attachments/assets/1202a022-57b7-4738-b9c1-9bdc1cd74fa0)

</details>

## Changelog
:cl:
add: russian radio prefixes are now fully handled in tgui-say. Enjoy your :т and :г
fix: fixed missing eventologist style for tgui-say
/:cl:
