### PR TITLE
Уборка контрабандных гибпушек у синего щита

### DIFF
--- a/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
+++ b/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
@@ -15,10 +15,7 @@
 			// а доставкой прилетит набор с оружием.
 			/obj/item/gun/energy/blueshield = /obj/item/storage/belt/holster/energy/blueshield,
 			/obj/item/gun/ballistic/automatic/sol_smg = /obj/item/storage/toolbox/guncase/nova/carwo_large_case/sindano,
-			/obj/item/gun/ballistic/automatic/xhihao_smg = /obj/item/storage/toolbox/guncase/nova/xhihao_large_case/bogseo,
-			/obj/item/gun/ballistic/automatic/wt550 = /obj/item/storage/toolbox/guncase/nova/wt550,
 			/obj/item/gun/ballistic/automatic/nt20 = /obj/item/storage/toolbox/guncase/nova/nt20,
-			/obj/item/gun/ballistic/shotgun/katyusha = /obj/item/storage/toolbox/guncase/nova/katyusha,
 		)
 		for(var/obj/item/weapon as anything in possible_weapons)
 			blueshield_weapons[initial(weapon.name)] = possible_weapons[weapon]


### PR DESCRIPTION
## О Pull Request

Апдейт который давно все ждали: УДАЛЕНИЕ КОНТРАБАНДНОГО ОРУЖИЯ из маячка синего щита. Рукой лично Джека Трейзена удален: WT-550, Bogseo, и уже успевшая нашуметь Katyusha (оно даже мощнее бульдога синдиката, камон). После апдейта бщ будет доступен: SR-8, Sindano и NT20. Отмечу исключительно каноничные NT и легальные пушки.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Сервер вздохнет спокойно.

## Changelog

:cl:
balance: из маячка БЩ убрана Katyusha, WT-550 и Bogseo. Теперь только легальные и каноничные NT пушки.
/:cl:
