### PR TITLE
Нерф турелей ратвара.

### DIFF
--- a/modular_nova/modules/clock_cult/code/structures/ocular_warden.dm
+++ b/modular_nova/modules/clock_cult/code/structures/ocular_warden.dm
@@ -61,7 +61,7 @@
 	dir = get_dir(get_turf(src), get_turf(target))
 
 	// Apply 15 damage (- 1 for each tile away they are), or 7.5, whichever is larger
-	target.apply_damage(max(BASE_DAMAGE - (get_dist(src, target) * DAMAGE_FALLOFF), MINIMUM_DAMAGE) * seconds_per_tick, BURN)
+	target.apply_damage(max(BASE_DAMAGE) * seconds_per_tick, BURN)
 
 	new /obj/effect/temp_visual/ratvar/ocular_warden(get_turf(target))
 	new /obj/effect/temp_visual/ratvar/ocular_warden(get_turf(src))


### PR DESCRIPTION

## О Pull Request

Нерф турелей ратвара. Уменьшение урона до фиксированных 15, вместо 20-25.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

В данный момент турели становятся МВП постройкой ратвара, которая в купе с другими турелями унижает офицеров. Они наносят около 20-25 урона, ожоги 2-3 степени и полностью игнорируют броню, а в это время до тебя домогается культист ратвара. Две турели вместе убивают за 3-4 выстрела.

Уменьшив урон, офицеры получат шанс сломать турель и не умереть во время этого процесса.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

![image](https://github.com/user-attachments/assets/6c32c7da-917e-46c6-a4cd-e1e596aaa57a)

</details>

## Changelog

:cl: Saukykouko
balance: Rat'var's turrets nerf
/:cl:
