### PR TITLE
[TM-ONLY] Katyusha removed from blueshield beacon

### DIFF
--- a/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
+++ b/tff_modular/modules/blueshield-rearm/code/weapon_beacon.dm
@@ -18,7 +18,7 @@
 			/obj/item/gun/ballistic/automatic/xhihao_smg = /obj/item/storage/toolbox/guncase/nova/xhihao_large_case/bogseo,
 			/obj/item/gun/ballistic/automatic/wt550 = /obj/item/storage/toolbox/guncase/nova/wt550,
 			/obj/item/gun/ballistic/automatic/nt20 = /obj/item/storage/toolbox/guncase/nova/nt20,
-			/obj/item/gun/ballistic/shotgun/katyusha = /obj/item/storage/toolbox/guncase/nova/katyusha,
+			// /obj/item/gun/ballistic/shotgun/katyusha = /obj/item/storage/toolbox/guncase/nova/katyusha,
 		)
 		for(var/obj/item/weapon as anything in possible_weapons)
 			blueshield_weapons[initial(weapon.name)] = possible_weapons[weapon]


### PR DESCRIPTION

## О Pull Request

Вывод Катюши из маячка БЩ до переписывания его статуса в вики.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Контрабандному оружию и вооружению высокой летальности и атакующей способности нечего делать у телохранителя прямо с коробки.

## Доказательства тестирования

-

## Changelog
:cl:
balance: Katyusha has been temporarily removed before wiki redaction.
/:cl:
