### PR TITLE
tweak katyusha/ weight

### DIFF
--- a/tff_modular/modules/gun_balance/shotgun.dm
+++ b/tff_modular/modules/gun_balance/shotgun.dm
@@ -21,3 +21,9 @@
 
 /obj/item/ammo_casing/shotgun/antitide
 	variance = 22
+
+/obj/item/gun/ballistic/shotgun/katyusha
+	weapon_weight = WEAPON_HEAVY
+
+/obj/item/gun/ballistic/shotgun/katyusha/shitzu
+	slot_flags = ITEM_SLOT_BACK


### PR DESCRIPTION
## О Pull Request

Делает катюшу и производные ему (Jager, Shitzu) двуручными, также запрещает их вешать на пояс, только на спину, как и все дробовики.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Одноручный автоматический барабанный дробовик, ну куда еще?

## Changelog

:cl:
balance: делает катюшу и производны ему дробовики двуручными и запрещает носить на поясе
/:cl:
