### PR TITLE
"Balancing" genetic mutation quirk

### DIFF
--- a/modular_nova/master_files/code/datums/quirks/positive_quirks/genetic_freak.dm
+++ b/modular_nova/master_files/code/datums/quirks/positive_quirks/genetic_freak.dm
@@ -5,11 +5,20 @@ GLOBAL_LIST_INIT(genetic_mutation_choice, list(
 	"Anti-Glowy" = /datum/mutation/human/glow/anti,
 	"Strength" = /datum/mutation/human/strong,
 	"Stimmed" = /datum/mutation/human/stimmed,
+	/**
 	"Chameleon" = /datum/mutation/human/chameleon,
+	*/ //FLUFFY FRONTIER GENETIC MUTATION QUIRK REBALANCE REMOVAL
 	"Geladikinesis" = /datum/mutation/human/geladikinesis,
 	"Cindikinesis" = /datum/mutation/human/cindikinesis,
 	"Transcendent Olfaction" = /datum/mutation/human/olfaction,
+	/**
 	"Elastic Arms" = /datum/mutation/human/elastic_arms,
+	*/ // FLUFFY FRONTIER GENETIC MUTATION QUIRK REBALANCE REMOVAL
+	// FLUFFY FRONTIER GENETIC MUTATION QUIRK REBALANCE ADD START
+	"Rock Eater" = /datum/mutation/human/rock_eater,
+	"Farsight" = /datum/mutation/human/farsight,
+	"Mending Touch" = /datum/mutation/human/lay_on_hands,
+	// FLUFFY FRONTIER GENETIC MUTATION QUIRK REBALANCE ADD END
 	"Webbing" = /datum/mutation/human/webbing,
 ))
 


### PR DESCRIPTION

## О Pull Request
Убираем наши любимые гены хамелеона и пластичных рук, а на замену их добавляем парочку небольших - поедатель камней, дальнозоркость и лечащее касание.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Вот бы у нас еще ролевая игра была.. А так, не будет смешных мин в виде СБухи или антага в техах под геном невидимости.
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
:cl:
add: Rock Eater, Farsight and Mending Touch was added to "Genetic Mutation" quirk
del: Chameleon and Elastic Arms mutations was removed from "Genetic Mutation" quirk
/:cl:
