### PR TITLE
Разнерф веспы

### DIFF
--- a/tff_modular/modules/gun_balance/pistols.dm
+++ b/tff_modular/modules/gun_balance/pistols.dm
@@ -1,6 +1,3 @@
-/obj/item/gun/ballistic/automatic/pistol/sol
-	spread = 15
-
 /obj/item/gun/ballistic/automatic/pistol/plasma_thrower
 	fire_delay = 0.2 SECONDS
 	spread = 22


### PR DESCRIPTION

Веспа теперь пистолет который стреляет одиночными. нет смысла все еще выдавать ему штраф к точности.
## О Pull Request
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
снова можно использовать пистолет и не промазывать
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog
:cl:
balance: к гуэпэ приварили обратно мушку
/:cl:
