### PR TITLE
Отключаем компиляцию карт тг

### DIFF
--- a/.github/workflows/compile_all_maps.yml
+++ b/.github/workflows/compile_all_maps.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   compile_all_maps:
     runs-on: ubuntu-22.04
-    timeout-minutes: 10 # FLUFFY FRINTIER EDIT. ORIGINAL 5
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -15,7 +15,8 @@
 		#include "map_files\tramstation\tramstation.dmm"
 		#include "map_files\NebulaStation\NebulaStation.dmm"
 		#include "map_files\wawastation\wawastation.dmm"
-		*/ // FLUFFY FRONTIER EDIT END
+		*/
+		// FLUFFY FRONTIER EDIT END
 		// NOVA EDIT ADDITION START - Compiling our modular maps too!
 		#include "map_files\VoidRaptor\VoidRaptor.dmm"
 		#include "map_files\NSVBlueshift\Blueshift.dmm"

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -4,6 +4,7 @@
 
 #ifndef LOWMEMORYMODE
 	#ifdef ALL_MAPS
+		/* // FLUFFY FRONTIER EDIT START. REMOVAL
 		#include "map_files\Birdshot\birdshot.dmm"
 		#include "map_files\debug\multiz.dmm"
 		#include "map_files\debug\runtimestation.dmm"
@@ -14,6 +15,7 @@
 		#include "map_files\tramstation\tramstation.dmm"
 		#include "map_files\NebulaStation\NebulaStation.dmm"
 		#include "map_files\wawastation\wawastation.dmm"
+		*/ // FLUFFY FRONTIER EDIT END
 		// NOVA EDIT ADDITION START - Compiling our modular maps too!
 		#include "map_files\VoidRaptor\VoidRaptor.dmm"
 		#include "map_files\NSVBlueshift\Blueshift.dmm"


### PR DESCRIPTION
Никак влияет ни на что для игроков. Должно уменьшить нагрузку на тесты, проходящие на серверах нашего любимого гитхаба (и избавить меня от нужды перезапускать их по 10 раз)

![image](https://github.com/user-attachments/assets/bcddbd03-d9a7-4ded-817b-e441ac83a0d2)
