### PR TITLE
Ребаланс блоба под пушки новы

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -1,11 +1,11 @@
 // Overmind defines
 
-#define OVERMIND_MAX_POINTS_DEFAULT 100 // Max point storage
+#define OVERMIND_MAX_POINTS_DEFAULT 150 // Max point storage. FLUFFY FRONTIER CHANGES - BUFF BLOB, ORIGINAL: 100
 #define OVERMIND_STARTING_POINTS 60 // Points granted upon start
 #define OVERMIND_STARTING_REROLLS 1 // Free strain rerolls at the start
 #define OVERMIND_STARTING_MIN_PLACE_TIME (1 MINUTES) // Minimum time before the core can be placed
 #define OVERMIND_STARTING_AUTO_PLACE_TIME (6 MINUTES) // After this time, randomly place the core somewhere viable
-#define OVERMIND_WIN_CONDITION_AMOUNT 400 // Blob structures required to win
+#define OVERMIND_WIN_CONDITION_AMOUNT 550 // Blob structures required to win, FLUFFY FRONTIER CHANGES - BUFF BLOB, ORIGINAL: 400
 #define OVERMIND_ANNOUNCEMENT_MIN_SIZE 75 // Once the blob has this many structures, announce their presence
 #define OVERMIND_ANNOUNCEMENT_MAX_TIME (10 MINUTES) // If the blob hasn't reached the minimum size before this time, announce their presence
 #define OVERMIND_MAX_CAMERA_STRAY "3x3" // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc
@@ -50,9 +50,9 @@
 #define BLOB_RESOURCE_MAX_HP 60
 #define BLOB_RESOURCE_HP_REGEN 15
 #define BLOB_RESOURCE_MIN_DISTANCE 4 // Minimum distance between resource blobs
-#define BLOB_RESOURCE_GATHER_DELAY (4 SECONDS) // Gather points when pulsed outside this interval
+#define BLOB_RESOURCE_GATHER_DELAY (3.75 SECONDS) // Gather points when pulsed outside this interval, FLUFFY FRONTIER CHANGES - BUFF BLOB, ORIGINAL: 4
 #define BLOB_RESOURCE_GATHER_ADDED_DELAY (0.25 SECONDS) // Every additional resource blob adds this amount to the gather delay
-#define BLOB_RESOURCE_GATHER_AMOUNT 1 // The amount of points added to the overmind
+#define BLOB_RESOURCE_GATHER_AMOUNT 1.5 // The amount of points added to the overmind, FLUFFY FRONTIER CHANGES - BUFF BLOB, ORIGINAL: 1
 
 #define BLOB_REGULAR_MAX_HP 25
 #define BLOB_REGULAR_HP_INIT 21 // The starting HP of a normal blob tile


### PR DESCRIPTION
## О Pull Request

Уменьшить КД создания ресурсов ресурсками с 4 до 3.75 (каждая новая ресурска медленнее на 0.25)
Увеличение регена поинтов ресурсок блоба с 1 до 1.5
Увеличение требуемых тайлов блоба для победы с 400 до 550
Увеличение максимального количества поинтов ресурсов с 100 до 150.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Блоб имеет ТГшный баланс, поэтому страдает от скорострельных пушек новы и исчезает достаточно быстро от ММРки или дробовиков с лазерными дробями. Это бы не было проблемой, если бы не тот факт что получение ресурсов у блоба очень медленная для новабаланса.
Чтобы расшириться на 1 тайл, нужно потратить 4 РЕСУРСА, примерно столько же и для атаки, и это все когда у блоба производство по 1 за ресурску + уменьшение скорости производства за каждую новую, а вокруг около 10 игроков. Потребление слишком большое - когда тебе нужно кого-то убить, ты тратишь все свои запасы из-за того что у кукл ХП больше чем на ТГ. Дефицит должен быть - не спорю, но не такой же, когда админы вынуждены баффать блоба педально и давать ему 100 поинтов по несколько раз (это не помогает), потому что запасы уходят слишком быстро.
А ведь блоб мажор. 

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

![image](https://github.com/user-attachments/assets/9492a3c4-c7ec-4f76-893f-4d0cdcfe101c)

![image](https://github.com/user-attachments/assets/1cc736a5-757a-4a2c-801f-8bac542cefff)


</details>

## Changelog

:cl: Saukykouko
balance: Уменьшено КД производства ресурсов у блоба с 4 до 3.75, увеличение максимального количества поинтов ресурсов с 100 до 150, увеличение требуемого количества тайлов для победы с 400 до 550, увеличение производства ресурсов ресурсками с 1 до 1.5
/:cl:
