### PR TITLE
МОД контрактора больше не замедляет.

### DIFF
--- a/modular_nova/modules/contractor/code/items/modsuit/theme.dm
+++ b/modular_nova/modules/contractor/code/items/modsuit/theme.dm
@@ -15,7 +15,7 @@
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	siemens_coefficient = 0
-	slowdown_deployed = 0.5
+	slowdown_deployed = 0.0 // FLUFFY FRONTIER CHANGES - ORIGINAL: 0.5
 	ui_theme = "syndicate"
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster/contractor, /obj/item/mod/module/chameleon/contractor)
 	allowed_suit_storage = list(


### PR DESCRIPTION
## О Pull Request

По какой-то неизвестной мне причине, замедление у МОДа контрактора равно 0.5, что равно офицерскому.
МОД контрактора не должен замедлять так сильно, учитывая что у контрактора нет альтернативной брони, на которую он может заменить МОД.
Убирает полностью замедление до 0.0

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Инвалиды станут менее инвалидными.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

</details>

## Changelog

:cl: SaukyKouko
balance: МОД контрактора больше не замедляет
/:cl:
