### PR TITLE
Useless notes panel

### DIFF
--- a/tff_modular/modules/admin/verbs/notes_panel.dm
+++ b/tff_modular/modules/admin/verbs/notes_panel.dm
@@ -1,0 +1,3 @@
+ADMIN_VERB(notes_panel, R_ADMIN, "Player Notes Panel", "Shows Player Notes.", ADMIN_CATEGORY_GAME)
+	browse_messages(target_ckey = user.ckey, agegate = FALSE)
+	BLACKBOX_LOG_ADMIN_VERB("Player Notes Panel")

--- a/tff_modular/modules/admin/verbs/notes_panel.dm
+++ b/tff_modular/modules/admin/verbs/notes_panel.dm
@@ -1,3 +1,3 @@
-ADMIN_VERB(notes_panel, R_ADMIN, "Player Notes Panel", "Shows Player Notes.", ADMIN_CATEGORY_GAME)
+ADMIN_VERB(notes_panel, R_ADMIN, "Player Notes Panel", "Shows Player Notes.", ADMIN_CATEGORY_MAIN)
 	browse_messages(target_ckey = user.ckey, agegate = FALSE)
 	BLACKBOX_LOG_ADMIN_VERB("Player Notes Panel")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9165,6 +9165,7 @@
 #include "tff_modular\master_files\code\modules\power\cable.dm"
 #include "tff_modular\master_files\code\modules\quirks_balance\quirks.dm"
 #include "tff_modular\master_files\code\modules\reagents\recipe\coagulant_recipe.dm"
+#include "tff_modular\modules\admin\verbs\notes_panel.dm"
 #include "tff_modular\modules\antagonism_updates\contractor_gear.dm"
 #include "tff_modular\modules\antagonism_updates\syndi_badass_armor\clothes.dm"
 #include "tff_modular\modules\autoaccent\code\autoaccent.dm"


### PR DESCRIPTION
## О Pull Request

Кто-то давно просил (Алекс), я давно сделал, но что-то совсем забыл сделать ПР
Ничего особенного - просто открывает нотесы самого себя
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Админам не надо жать ПКМ по случайной кукле -> Player Panel -> Notes, чтобы открыть эту менюшку
## Доказательства тестирования
Оно работает, проверено в том числе с подключенной ДБ.

<details>
<summary>Скриншоты/Видео</summary>

![image](https://github.com/user-attachments/assets/668107ca-b904-42e2-9b12-0c69619c6867)
</details>

## Changelog
:cl:
admin: added new way to open notes panel
/:cl:
