### PR TITLE
Изменение порогов у ICES (пока его не выпилили)

### DIFF
--- a/code/__DEFINES/~nova_defines/events.dm
+++ b/code/__DEFINES/~nova_defines/events.dm
@@ -5,8 +5,8 @@
  * The random define is for events such as anomalies so they are still run during higher level events.
  */
 
-#define EVENT_LOWPOP_THRESHOLD 45
-#define EVENT_MIDPOP_THRESHOLD 75
+#define EVENT_LOWPOP_THRESHOLD 35 // FLUFFY FRONTIER EDIT - original: #define EVENT_LOWPOP_THRESHOLD 45
+#define EVENT_MIDPOP_THRESHOLD 60 // FLUFFY FRONTIER EDIT - original: #define EVENT_MIDPOP_THRESHOLD 75
 #define EVENT_HIGHPOP_THRESHOLD 100
 #define EVENT_LOWPOP_TIMER_MULTIPLIER 2
 #define EVENT_MIDPOP_TIMER_MULTIPLIER 1.5


### PR DESCRIPTION

## О Pull Request

Снижает пороги игроков у лоу, мид ихайпопа у системы ICES.
Лоупоп до 35 (было до 45)
Мидпоп до 60 (было до 75)
## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Прошлые пороги были не очень подходящие для фф. Теперь получше
Ну и:
- Больше работы админам, ведь нужно отменять ивенты ICES
- Меньбше работы админам, ведь не нужно самому спавнить ивенты
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>

![image](https://github.com/user-attachments/assets/bc1d0c6d-d5dd-4f83-b14e-7419f36f8f8c)

</details>

## Changelog
:cl:
balance: EVENT_LOWPOP_THRESHOLD is now 35, EVENT_MIDPOP_THRESHOLD is now 60
/:cl:
