### PR TITLE
[TM-ONLY] Возможность автозаполнения полей в бумаге (и еще маленькие штуки)

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -631,7 +631,6 @@
 			return TRUE
 		if("add_text")
 			var/paper_input = params["text"]
-
 			var/this_input_length = length_char(paper_input)
 
 			if(this_input_length == 0)
@@ -711,7 +710,6 @@
 				log_paper("[key_name(user)] tried to write to [name] when it would exceed the length limit by [new_length - MAX_PAPER_LENGTH] characters: \"[paper_input]\"")
 				return TRUE
 			// FLUFFY FRONTIER ADDITION START
-
 			playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
 
 			add_raw_text(paper_input, writing_implement_data["font"], writing_implement_data["color"], writing_implement_data["use_bold"], check_rights_for(user?.client, R_FUN))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -632,11 +632,6 @@
 		if("add_text")
 			var/paper_input = params["text"]
 
-			if(findtext_char(paper_input, regex(@"\%.+\%")))
-				paper_input = replacetext_char(paper_input, "%sig%", "[user.real_name]")
-				paper_input = replacetext_char(paper_input, "%time%", "[time2text(world.timeofday, "hh:mm", NO_TIMEZONE)]")
-				paper_input = replacetext_char(paper_input, "%date%", "[time2text(world.timeofday, "DD/MM", NO_TIMEZONE)]/[CURRENT_STATION_YEAR]")
-
 			var/this_input_length = length_char(paper_input)
 
 			if(this_input_length == 0)
@@ -664,38 +659,58 @@
 				return TRUE
 
 			var/current_length = get_total_length()
+			/* // FLUFFY FRONTIER EDIT START - этот же кусок кода теперь чуть ниже
 			var/new_length = current_length + this_input_length
 
 			// tgui should prevent this outcome.
 			if(new_length > MAX_PAPER_LENGTH)
 				log_paper("[key_name(user)] tried to write to [name] when it would exceed the length limit by [new_length - MAX_PAPER_LENGTH] characters: \"[paper_input]\"")
 				return TRUE
+			*/ // FLUFFY FRONTIER EDIT END
 
 			// Safe to assume there are writing implement details as user.can_write(...) fails with an invalid writing implement.
 			var/writing_implement_data = holding.get_writing_implement_details()
 
-			// FLUFF START
-			var/regex/reg = regex(@"\%\|(.+?)(?:\{(\d+)\})?\|\%|(\[_+\])", "g")
-			var/current_field_id = input_field_count
-			var/list/new_field_to_add = list()
-			while(reg.Find_char(paper_input))
-				message_admins("[reg.match] - [reg.group[1]] - [reg.group[2]] - [reg.index] - [reg.next]")
-				if(!isnull(reg.group[1]))
-					add_field_input(
-						"[current_field_id]",
-						reg.group[1],
-						writing_implement_data["font"],
-						writing_implement_data["color"],
-						writing_implement_data["use_bold"],
-						user.real_name
-					)
-					new_field_to_add += list(list(reg.match, max(length(reg.group[1]) + 1, text2num(reg.group[2]))))
-				current_field_id += 1
+			// FLUFFY FRONTIER ADDITION START
+			if(findtext_char(paper_input, regex(@"\%.+\%")))
+				paper_input = replacetext_char(paper_input, "%sig%", "[user.real_name]")
+				paper_input = replacetext_char(paper_input, "%time%", "[time2text(world.timeofday, "hh:mm", NO_TIMEZONE)]")
+				paper_input = replacetext_char(paper_input, "%date%", "[time2text(world.timeofday, "DD/MM", NO_TIMEZONE)]/[CURRENT_STATION_YEAR]")
 
-			for(var/field in new_field_to_add)
-				var/field_text = "\[[jointext(new/list(field[2]), "_")]\]" // Creates a string like `[___]`, where `_` is repeats field[2] times
-				paper_input = replacetext_char(paper_input, field[1], field_text)
-			// FLUFF END
+				// Нам необходимо так же искать и обычные поля (`[___]`), ведь иначе мы не сможешь высчитать правильный id для данных поля.
+				// По этой причине в этой регулярке и имеется чать "|(\[_+\])".
+				// Сама регулярка ищет данные вида "%|текст{длина_поля}|%". Часть "{длина_поля}" является необязательной.
+				// Текст находится в первой группе, длина поля во второй группе.
+				var/regex/reg = regex(@"\%\|(.+?)(?:\{(\d+)\})?\|\%|(\[_+\])", "g")
+				var/current_field_id = input_field_count
+				var/list/new_field_to_add = list() // list(list(`%|текст|%`, `длина этого поля`)) <- посмотирте код дальше, может поймете лучше, что я хотел сказать
+				while(reg.Find_char(paper_input))
+					if(!isnull(reg.group[1])) // Если нет текста в первой группе - значит это обычное поле
+						add_field_input(
+							"[current_field_id]",
+							reg.group[1],
+							writing_implement_data["font"],
+							writing_implement_data["color"],
+							writing_implement_data["use_bold"],
+							user.real_name
+						)
+						// Длина нового поля это макимальное из указанной длины_поля и (длины текста + 1)
+						new_field_to_add += list(list(reg.match, max(length(reg.group[1]) + 1, text2num(reg.group[2]))))
+					current_field_id += 1
+
+				// Замена %|текст|% на классическое поле [____]
+				for(var/field in new_field_to_add)
+					var/field_text = "\[[jointext(new/list(field[2]), "_")]\]" // Creates a string like `[___]`, where `_` is repeats field[2] times
+					paper_input = replacetext_char(paper_input, field[1], field_text)
+
+			this_input_length = length_char(paper_input)
+			var/new_length = current_length + this_input_length
+
+			// tgui should prevent this outcome.
+			if(new_length > MAX_PAPER_LENGTH)
+				log_paper("[key_name(user)] tried to write to [name] when it would exceed the length limit by [new_length - MAX_PAPER_LENGTH] characters: \"[paper_input]\"")
+				return TRUE
+			// FLUFFY FRONTIER ADDITION START
 
 			playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
 

--- a/tgui/packages/tgui/interfaces/PaperSheet/Preview.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet/Preview.tsx
@@ -497,7 +497,7 @@ export class PreviewView extends Component<PreviewViewProps> {
     input.defaultValue = fieldData.raw_text;
     input.disabled = true;
 
-    return `${input.outerHTML}`;
+    return `${input.outerHTML}`; // FLUFFY FRONTIER EDIT - ORIGINAL: return `[${input.outerHTML}]`;
   };
 
   render() {

--- a/tgui/packages/tgui/interfaces/PaperSheet/Preview.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet/Preview.tsx
@@ -497,7 +497,7 @@ export class PreviewView extends Component<PreviewViewProps> {
     input.defaultValue = fieldData.raw_text;
     input.disabled = true;
 
-    return `[${input.outerHTML}]`;
+    return `${input.outerHTML}`;
   };
 
   render() {


### PR DESCRIPTION
<!-- Пиши **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе это может быть невидимым. -->
<!-- Вы можете просмотреть Contributing.MD для подробного описания процесса PR. -->

## О Pull Request

Это первая версия этой штуки и вероятно она может измениться и/или пойти на апстримы. Поэтому только ТМ, если он будет.

Добавляет 3 новых "тега" или кодовых слов: `%sig%`, `%date%`, `%time%`:
- `%sig%` - оставляет подпись персонажа (аналог %s или %sign)
- `%date%` - оставляет текущую дату  (аналог %d или %date)
- `%time%` - оставляет текущую время  (аналог %t или %time)

<details>
<summary>Видео</summary>

https://github.com/user-attachments/assets/e13eb9e3-447d-47ba-aa85-00ca8b19ea02

</details>

Добавляет возможность создавать поля `[_____]`, которые сразу же будут заполненные.
Имеют написание вида: `%|текст{размер_поля}|%`. Часть "{размер_поля}" является не обязательной (в таком случае размером поля будет размер текста).

<details>
<summary>Видео</summary>

https://github.com/user-attachments/assets/4e3ebc8a-21f8-4cd7-a2e6-323f6e6c972b

</details>

Известная проблема:
- При использовании этих штук в факс панели - они не применятся (что по сути убивает одно из главных применений этих штук)
![image](https://github.com/user-attachments/assets/a78adaed-414a-4bcc-a971-e190e928f44a)


<!-- Опишите PR. Пожалуйста, убедитесь, что каждое изменение задокументировано, иначе это может задержать проверку и даже помешать мейнтейнеру замерджить ваш PR! -->

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Это сделает возможность создавать заранее заполненные документы и быстро их отправлять, без надобности в долгом дозаполнении документа

<!-- Пожалуйста, добавьте краткое описание того, почему, по вашему мнению, эти изменения принесут пользу игре и ролевой атмосфере сервера. Если вы не можете обосновать это словами, возможно тогда это не стоит добавлять. -->

## Доказательства тестирования

<!-- Вложите все скриншоты/видео/шаги отладки успешно работающего кода между блоками кода </summary> и </details>. -->
<!-- Нашим мапперам и спрайтерам: Публикация скриншотов контента ВНУТРИ РЕДАКТОРОВ (aseprite, PDN, SDMM и т. д.) НЕ является действительным доказательством тестирования. Пожалуйста, убедитесь, что вы скомпилировали игру и предоставили ДОКАЗАТЕЛЬСТВО того, что вы тестировали свои изменения. -->

Скрины и видео выше.

## Changelog

<!-- Если ваш PR изменяет аспекты игры, которые могут быть конкретно замечены игроками или администраторами, вы должны добавить changelog. Если ваше изменение НЕ соответствует этому описанию, удалите этот раздел. Сами строки ченджлога должны быть строго на английском. -->

:cl:
qol: Добавлена возможность автозаполнения полей с помощью конструкции %|текст{размер_поля}|%.
qol: Добавлены ключевые слова %sig%, %time%, %date%, которые позволяют вставить в текст документа сразу вашу подпись, текущее время и дату (т.е. без использования полей)
/:cl:

<!-- Оба :cl: необходимы для работы списка изменений! Вы можете поставить свое имя справа от первого :cl:, если хотите перезаписать свое имя пользователя GitHub в качестве автора в ченджлоге игры. -->
<!-- Вы можете использовать несколько одинаковых префиксов (они используются только для иконки в игре) и удалить ненужные. Несмотря на некоторые теги, ченджлоги в целом должны представлять, как изменения могут повлиять на игрока, а не краткое изложение содержания PR. -->
