### PR TITLE
fix the defenestreur blackmarket kit not spawning

### DIFF
--- a/tff_modular/master_files/code/modules/cargo/markets/market_items/weapons.dm
+++ b/tff_modular/master_files/code/modules/cargo/markets/market_items/weapons.dm
@@ -1,7 +1,7 @@
 /datum/market_item/weapon/trappiste_small_case
 	name = "Défenestreur gun kit"
 	desc = "That took way too much effort, no discount."
-	item = 	/obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case
+	item = 	/obj/item/storage/toolbox/guncase/nova/pistol/trappiste_small_case/skild
 	stock = 1
 	price_min = CARGO_CRATE_VALUE * 6
 	price_max = CARGO_CRATE_VALUE * 8


### PR DESCRIPTION

## О Pull Request

Теперь при покупке на черном рынке мы получаем НЕ пустую коробку
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>
Проверил. Отвечаю. Всего пять-шесть символов изменений емае
</details>

## Changelog
:cl:
fix: the skild AKA Defenestereur actually spawns after black market purchases
/:cl:
