### PR TITLE
Менее радикальный способ отключить ГБП

### DIFF
--- a/.github/workflows/gbp.yml
+++ b/.github/workflows/gbp.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
         id: value_holder
         env:
-          ENABLER_SECRET: ${{ secrets.ACTION_ENABLER }}
+          ENABLER_SECRET: ${{ secrets.GBP_ENABLER }} # FLUFFY FRONTIER EDIT - original:  ENABLER_SECRET: ${{ secrets.ACTION_ENABLER }}
         run: |
           unset SECRET_EXISTS
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi

--- a/.github/workflows/gbp_collect.yml
+++ b/.github/workflows/gbp_collect.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
         id: value_holder
         env:
-          ENABLER_SECRET: ${{ secrets.ACTION_ENABLER }}
+          ENABLER_SECRET: ${{ secrets.GBP_ENABLER }} # FLUFFY FRONTIER EDIT - original:  ENABLER_SECRET: ${{ secrets.ACTION_ENABLER }}
         run: |
           unset SECRET_EXISTS
           if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi


### PR DESCRIPTION
## О Pull Request

Дает возможность отключать рабочие потоки, связанные с GBP, при этом не используя грубое отключение потока на самом гитхабе

Почему это хорошо? 
К сожалению, на апстримах автолейблер находится в одном рабочем потоке, что и штука, связанная с GBP. Вообще, эту штуку можно вполне отключить, но для этого проверяется секрет ACTION_ENABLER. Но этот секрет так же отвечает и за авточенджлог. Поэтому я просто поменял проверку с наличия секрета ACTION_ENABLER, на проверку секрета GBP_ENABLER (конечно можно просто закомментировать, но я выбрал такой вариант). Это позволит включить рабочий поток Label and GBP и он не будет выдавать ошибки

Как альтернативу можно создать свой рабочий поток с автолейблером... Но, как по мне, это не очень надежно, ведь он будет привязан к другому файлу в коде. Если апстримы что-то поменяют - у нас все может сломаться. А копировать ради этого 3 файла - что-то перебор какой-то. Явно хуже, чем 2 измененных строчки (по моему мнению)

В общем вот, да
