### PR TITLE
Fix nss journey pt2

### DIFF
--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -4038,7 +4038,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "aDO" = (
@@ -28591,10 +28590,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"dgI" = (
-/obj/structure/cable/multilayer/connected,
-/turf/open/space/basic,
-/area/space)
 "dgP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -31214,6 +31209,7 @@
 	dir = 1;
 	name = "green line"
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "eLI" = (
@@ -99696,7 +99692,7 @@ xzh
 xzh
 xzh
 xzh
-dgI
+xzh
 xzh
 ctZ
 ctZ

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -2692,7 +2692,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
-/area/station/commons/fitness)
+/area/station/commons/dorms)
 "awD" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -2970,7 +2970,7 @@
 	dir = 4;
 	icon_state = "darkcorner"
 	},
-/area/station/commons/fitness)
+/area/station/commons/dorms)
 "axV" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -3660,9 +3660,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "aBy" = (
-/obj/machinery/light/small/directional/west{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
@@ -3673,6 +3670,7 @@
 /obj/effect/turf_decal/siding/white/end{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aBz" = (
@@ -4056,6 +4054,7 @@
 	pixel_x = 7;
 	pixel_y = -6
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aDR" = (
@@ -4461,6 +4460,7 @@
 	dir = 8
 	},
 /obj/machinery/recharge_station,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aGn" = (
@@ -35552,9 +35552,6 @@
 /obj/machinery/door/airlock/bathroom{
 	name = "Cabin 2"
 	},
-/obj/machinery/light/small/directional/west{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/white/end{
 	dir = 4
 	},
@@ -47849,6 +47846,15 @@
 	dir = 5
 	},
 /area/station/service/chapel)
+"oVX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/dorms)
 "oWg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47876,9 +47882,6 @@
 	},
 /obj/machinery/door/airlock/bathroom{
 	name = "Cabin 1"
-	},
-/obj/machinery/light/small/directional/west{
-	dir = 1
 	},
 /obj/effect/turf_decal/siding/white/end{
 	dir = 4
@@ -50839,12 +50842,6 @@
 	color = "#784936"
 	},
 /area/station/service/bar)
-"qRO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/fitness)
 "qSu" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/stripes/line{
@@ -51705,7 +51702,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/station/commons/fitness)
+/area/station/commons/dorms)
 "rta" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -56257,7 +56254,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
-/area/station/commons/fitness)
+/area/station/commons/dorms)
 "ujY" = (
 /obj/effect/turf_decal/siding/wideplating/light/corner{
 	color = "#777575";
@@ -56934,7 +56931,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/station/commons/fitness)
+/area/station/commons/dorms)
 "uFd" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool/cobble/side{
@@ -59228,7 +59225,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/station/commons/fitness)
+/area/station/commons/dorms)
 "vVG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -96705,8 +96702,8 @@ aiA
 aiA
 aiA
 aiA
-rQR
-rQR
+arf
+arf
 hWz
 awr
 aBA
@@ -98760,7 +98757,7 @@ gxj
 nny
 nny
 nny
-nny
+oVX
 pqE
 tjE
 awr
@@ -99274,7 +99271,7 @@ wJK
 iJt
 psd
 aAo
-qRO
+kmR
 awr
 pxc
 awr

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -4439,6 +4439,13 @@
 /obj/structure/drain,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
+"aGq" = (
+/obj/machinery/door/window/left/directional/west{
+	name = "Atmospherics Delivery";
+	req_access = list("atmospherics")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aGs" = (
 /obj/machinery/requests_console{
 	department = "Research Director's Desk";
@@ -17746,12 +17753,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/door/window/right/directional/south{
 	name = "Brig Desk";
-	req_access = list("brig");
-	dir = 1
-	},
-/obj/machinery/door/window/right/directional/east{
-	name = "Brig Reception";
-	dir = 2
+	req_access = list("brig")
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -31116,7 +31118,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/engineering/break_room)
 "eHN" = (
 /obj/machinery/requests_console{
 	department = "Head of Personnel's Desk";
@@ -42041,10 +42043,11 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/obj/item/folder,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/carpet/blue,
 /area/station/security/detectives_office)
 "lnJ" = (
@@ -44537,6 +44540,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/prison/directional/east,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "mVZ" = (
@@ -53665,11 +53669,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/machinery/door/window/left/directional/west{
-	name = "Atmospherics Delivery";
-	req_access = list("atmospherics");
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
@@ -59546,11 +59545,11 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	req_access = list("security");
-	name = "Security Delivery"
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/door/window/left/directional/west{
+	name = "Security Delivery";
+	req_access = list("security")
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "wdA" = (
@@ -62264,14 +62263,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "xRc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig"
 	},
-/turf/closed/wall/r_wall,
-/area/station/science/genetics)
+/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "xRn" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt,
@@ -88838,7 +88844,7 @@ tcz
 ttn
 tcz
 tcz
-tcz
+vad
 uHO
 uca
 tcz
@@ -89095,7 +89101,7 @@ nXE
 kFq
 wot
 eUZ
-kFq
+xRc
 kFq
 kFq
 kFq
@@ -91231,7 +91237,7 @@ cbN
 xUo
 mKT
 kWJ
-tau
+jVO
 cay
 tau
 kul
@@ -91745,7 +91751,7 @@ guB
 dRO
 dzK
 dHo
-tau
+jVO
 bUt
 pAE
 cij
@@ -92002,7 +92008,7 @@ xCo
 bVp
 glK
 mNk
-tau
+jVO
 ceW
 tau
 cdk
@@ -92259,7 +92265,7 @@ ebv
 gkj
 quH
 xpl
-tau
+jVO
 tau
 tau
 cfb
@@ -93271,7 +93277,7 @@ bRa
 bLM
 bLM
 bNQ
-bOd
+aGq
 bOd
 bOd
 bSD
@@ -112263,7 +112269,7 @@ vQg
 gDc
 ePY
 bWq
-xRc
+bWq
 gEp
 gEp
 gEp

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -11299,7 +11299,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "bkN" = (
@@ -23714,7 +23713,6 @@
 /area/station/engineering/main)
 "cny" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "cnA" = (
@@ -46173,6 +46171,7 @@
 /obj/item/clothing/accessory/badge/holo/warden,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/machinery/recharger,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "nUe" = (
@@ -48629,6 +48628,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"puC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/station/engineering/main)
 "puJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -93696,8 +93705,8 @@ cfb
 cfb
 cfb
 clR
-kja
-ckH
+puC
+cgR
 cMm
 cMm
 cDt
@@ -93953,7 +93962,7 @@ aeS
 ahx
 cjk
 cmF
-kja
+puC
 bkM
 cqP
 cMm

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -872,14 +872,8 @@
 	},
 /area/station/engineering/main)
 "ajx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/turf/closed/wall/r_wall,
+/area/station/security/evidence)
 "ajC" = (
 /obj/item/beacon,
 /obj/effect/turf_decal/delivery/red,
@@ -1280,7 +1274,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "ane" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -1744,11 +1738,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/sink/directional/east,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "arf" = (
@@ -1908,7 +1899,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/area/station/security/checkpoint/customs)
 "ase" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -2493,12 +2484,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "avr" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/bed/pod,
 /obj/structure/window/spawner/directional/south,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "avs" = (
@@ -3469,10 +3457,7 @@
 /area/station/maintenance/department/electrical)
 "aAB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "aAC" = (
@@ -3859,15 +3844,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "aCB" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "aCC" = (
@@ -5315,6 +5296,8 @@
 /area/station/commons/storage/primary)
 "aKd" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aKe" = (
@@ -6364,23 +6347,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aOZ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/stack/ducts/fifty,
 /obj/item/stack/ducts/fifty,
 /obj/item/stack/ducts/fifty,
 /obj/item/stack/ducts/fifty,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/item/plunger,
 /obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "aPb" = (
@@ -8388,11 +8362,8 @@
 /turf/open/floor/plating,
 /area/station/construction)
 "aYi" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/start/barber,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "aYj" = (
@@ -8678,10 +8649,7 @@
 /area/station/science/ordnance/storage)
 "aYZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "aZd" = (
@@ -9083,10 +9051,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "baZ" = (
@@ -9281,10 +9246,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "bbR" = (
@@ -9484,20 +9446,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "bcH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "bcK" = (
@@ -9694,11 +9650,8 @@
 	dir = 1
 	},
 /obj/structure/secure_safe/directional/south,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/closet/secure_closet/barber,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "bdF" = (
@@ -10506,19 +10459,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "bhb" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/chem_dispenser,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bhc" = (
@@ -10529,17 +10473,7 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "bhd" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	id = "pharmacy_shutters";
 	name = "Pharmacy Shutter Control";
@@ -10547,6 +10481,7 @@
 	pixel_y = 24;
 	req_access = list("pharmacy")
 	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bhh" = (
@@ -11151,18 +11086,9 @@
 /area/station/medical/pharmacy)
 "bjO" = (
 /obj/machinery/chem_heater/withbuffer,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bjP" = (
@@ -11173,15 +11099,11 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bjQ" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/smartfridge/chemistry/preloaded,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bjR" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
@@ -11189,13 +11111,8 @@
 	},
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bjU" = (
@@ -12343,17 +12260,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bod" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/button/door{
 	id = "pharmacy_shutters2";
 	name = "Pharmacy Shutter Control";
@@ -12361,19 +12268,10 @@
 	pixel_y = -6;
 	req_access = list("pharmacy")
 	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "boe" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -12381,6 +12279,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
 "bof" = (
@@ -13596,17 +13495,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "btg" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "btn" = (
@@ -14069,16 +13959,6 @@
 /obj/machinery/door/airlock/medical{
 	name = "Medbay"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -14090,6 +13970,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "buH" = (
@@ -14312,54 +14193,27 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "bvh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/utility/welding,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvj" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvk" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "bvn" = (
@@ -14392,16 +14246,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "bvs" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage"
@@ -14409,6 +14253,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bvt" = (
@@ -15526,7 +15371,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/cargo/miningdock)
 "bAq" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/west,
@@ -15851,19 +15696,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bBL" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/item/stack/sheet/mineral/plasma,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bBM" = (
@@ -16942,17 +16778,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bFA" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bFB" = (
@@ -18631,15 +18458,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/dryer{
 	dir = 4;
 	pixel_x = -6;
 	pixel_y = -6
 	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "bLH" = (
@@ -18721,16 +18545,6 @@
 /turf/open/floor/carpet/blue,
 /area/station/medical/psychology)
 "bLX" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab"
@@ -18739,6 +18553,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "bLY" = (
@@ -20874,6 +20689,13 @@
 "bWn" = (
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/obj/item/stack/package_wrap,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "bWo" = (
@@ -28138,7 +27960,7 @@
 	name = "evidence closet 3"
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "cSE" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
@@ -28587,6 +28409,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
+"dcr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/prison/work)
 "dda" = (
 /obj/structure/table,
 /obj/item/inspector{
@@ -28651,10 +28479,7 @@
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/aft)
 "deo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "des" = (
@@ -28679,19 +28504,10 @@
 	req_access = list("medical")
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay)
 "dfw" = (
@@ -29101,16 +28917,6 @@
 /turf/open/floor/wood/tile,
 /area/station/common/pool)
 "dsR" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/right/directional/north{
@@ -29123,6 +28929,7 @@
 	id = "pharmacy_shutters2";
 	name = "Pharmacy Shutters"
 	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "dtA" = (
@@ -29572,7 +29379,7 @@
 "dIn" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "dIy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/lattice,
@@ -30220,7 +30027,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "eap" = (
 /obj/structure/table,
 /obj/item/taperecorder,
@@ -30559,11 +30366,8 @@
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "eli" = (
-/obj/machinery/plate_press{
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/bot,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "elm" = (
@@ -30664,11 +30468,8 @@
 /turf/open/floor/iron/goonplaque,
 /area/station/hallway/secondary/entry)
 "epc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "epk" = (
@@ -30723,7 +30524,7 @@
 	req_access = list("brig")
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "erI" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/cable,
@@ -32999,6 +32800,10 @@
 /area/station/engineering/main)
 "fRc" = (
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fRu" = (
@@ -33265,13 +33070,10 @@
 "fYH" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "fYT" = (
@@ -34230,14 +34032,11 @@
 	},
 /area/station/commons/dorms)
 "gES" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/table/reinforced/rglass,
 /obj/structure/window/spawner/directional/south,
 /obj/item/hairbrush,
 /obj/item/lipstick/random,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "gFg" = (
@@ -34456,7 +34255,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "gJP" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/keycard/library,
@@ -34557,7 +34356,7 @@
 /obj/item/bodybag,
 /obj/item/bodybag,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "gNi" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -34912,8 +34711,8 @@
 /area/station/cargo/miningdock)
 "gYM" = (
 /obj/machinery/smartfridge/organ,
-/obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "gYQ" = (
@@ -35499,10 +35298,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "hnt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
@@ -35511,16 +35306,11 @@
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Chemistry Lab East";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hnE" = (
@@ -35987,7 +35777,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "hCl" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/tile/neutral{
@@ -36066,6 +35856,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/prisoner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "hEb" = (
@@ -36196,7 +35987,7 @@
 /obj/structure/training_machine,
 /obj/item/target/syndicate,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "hIK" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -36655,11 +36446,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "hVF" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/work)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/range)
 "hVG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -37107,7 +36897,7 @@
 "ikh" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/area/station/hallway/primary/port)
 "ikq" = (
 /obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
@@ -37209,7 +36999,7 @@
 "imo" = (
 /obj/machinery/dish_drive/bullet,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "imH" = (
 /obj/effect/turf_decal/siding/purple/corner,
 /obj/structure/disposalpipe/segment{
@@ -38140,16 +37930,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "iSB" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/landmark/start/barber,
 /obj/machinery/button/curtain{
 	id = "barbershopcurtains1";
 	pixel_x = 25;
 	pixel_y = 24
 	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "iTj" = (
@@ -38176,8 +37963,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_cafeteria)
 "iTx" = (
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "iTH" = (
 /turf/open/floor/iron/chapel{
 	dir = 4
@@ -38418,7 +38206,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/station/cargo/storage)
 "jco" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -38536,7 +38324,7 @@
 /obj/item/target/syndicate,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "jgM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags{
@@ -38793,7 +38581,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "jnH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39112,12 +38900,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "jwX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/vending/barbervend,
 /obj/machinery/light/warm/directional/south,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "jxd" = (
@@ -40568,7 +40353,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "kps" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40837,15 +40622,10 @@
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "kxm" = (
-/obj/structure/table,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/stack/package_wrap,
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/work)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "kxX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
@@ -40901,7 +40681,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "kAt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -41022,16 +40802,6 @@
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "kCY" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/right/directional/west{
@@ -41040,6 +40810,7 @@
 	},
 /obj/item/folder/white,
 /obj/item/pen,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "kDh" = (
@@ -41102,7 +40873,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "kDW" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 10
@@ -41571,15 +41342,13 @@
 	},
 /area/station/science/research)
 "kSH" = (
+/turf/open/floor/iron/dark,
+/area/station/security/range)
+"kTc" = (
+/obj/effect/turf_decal/bot,
 /obj/machinery/plate_press{
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/work)
-"kTc" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "kTm" = (
@@ -41617,7 +41386,7 @@
 "kUu" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "kUA" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -42022,7 +41791,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "liE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43039,7 +42808,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/commons/dorms)
+/area/station/maintenance/starboard/fore)
 "lOw" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -43082,7 +42851,7 @@
 "lPs" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "lPO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -43413,16 +43182,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lZG" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage"
@@ -43430,6 +43189,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "mbf" = (
@@ -43452,8 +43212,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mbF" = (
-/obj/structure/loom,
 /obj/effect/turf_decal/bot,
+/obj/structure/frame/machine,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "mci" = (
@@ -43744,11 +43504,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "mnh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/work)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/security/brig)
 "moA" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Bridge Delivery";
@@ -43886,17 +43643,8 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "mrM" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "mrS" = (
@@ -44010,8 +43758,8 @@
 /area/station/science/robotics/lab)
 "myc" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/smartfridge/chemistry/preloaded,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mys" = (
@@ -44113,19 +43861,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mCl" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/chem_dispenser,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mCo" = (
@@ -44625,7 +44364,7 @@
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "mUx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -44776,16 +44515,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "mYY" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Surgery A"
@@ -44794,6 +44523,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/surgery)
 "mZc" = (
@@ -44834,16 +44564,6 @@
 	},
 /area/station/security/courtroom)
 "naY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -44852,6 +44572,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "nbg" = (
@@ -45155,16 +44876,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "nlN" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Pharmacy"
@@ -45173,6 +44884,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "nlQ" = (
@@ -45609,14 +45321,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
 "nzH" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/chair/comfy/barber_chair{
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "nAp" = (
@@ -45716,10 +45425,6 @@
 /area/station/ai_monitored/command/storage/eva)
 "nCP" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/light_switch/directional/south,
 /obj/structure/chair{
 	dir = 1
@@ -45729,6 +45434,7 @@
 	pixel_x = 25;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "nCS" = (
@@ -46532,14 +46238,11 @@
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "nXi" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Barbershop"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "nXE" = (
@@ -46702,7 +46405,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/hallway/primary/port)
+/area/station/maintenance/fore)
 "obL" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -47293,12 +46996,9 @@
 /area/station/common/pool)
 "ouv" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/light/warm/directional/north,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "ouy" = (
@@ -47417,7 +47117,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
+/area/station/hallway/primary/port)
 "oxX" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -47442,6 +47142,10 @@
 "oyo" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/plate_press{
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "oyN" = (
@@ -48077,7 +47781,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "oUg" = (
 /obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/bot/secbot/beepsky/armsky,
@@ -48303,6 +48007,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"oZn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "oZs" = (
 /obj/structure/table,
 /obj/item/clothing/suit/jacket/straight_jacket,
@@ -48785,7 +48494,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "ppW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
@@ -48926,19 +48635,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/abandon_cafeteria)
 "pva" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/chem_dispenser,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pvi" = (
@@ -49134,10 +48834,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "pAR" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
 	pixel_x = 2;
@@ -49145,14 +48841,9 @@
 	},
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pAS" = (
@@ -49339,15 +49030,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "pIc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/west,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "pII" = (
@@ -49460,7 +49148,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "pMv" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/science,
@@ -49474,6 +49162,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"pOz" = (
+/obj/vehicle/sealed/mecha/ripley/cargo,
+/turf/open/floor/iron/recharge_floor,
+/area/station/cargo/storage)
 "pOC" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/white,
@@ -49502,7 +49194,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "pOU" = (
 /obj/machinery/button/door/directional/west{
 	id = "commissarydoor";
@@ -50109,16 +49801,8 @@
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
 "qkP" = (
-/obj/structure/table,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
-/obj/item/stack/package_wrap,
-/obj/item/pen/fountain,
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/work)
+/turf/closed/wall/r_wall,
+/area/station/security/range)
 "qlB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -50282,9 +49966,9 @@
 "qqN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "qqU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -50341,16 +50025,6 @@
 	},
 /area/station/commons/fitness)
 "qrK" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/right/directional/west{
@@ -50364,6 +50038,7 @@
 	name = "Pharmacy Shutters";
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "qsj" = (
@@ -51668,14 +51343,14 @@
 	req_access = list("brig")
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "rhx" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "rhJ" = (
 /turf/closed/wall,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "rhN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52375,9 +52050,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -52748,7 +52420,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "rTX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52972,19 +52644,10 @@
 /area/station/commons/vacant_room)
 "sbn" = (
 /obj/machinery/chem_heater/withbuffer,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "sbJ" = (
@@ -53066,16 +52729,6 @@
 	},
 /area/station/service/chapel)
 "sdT" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -53084,6 +52737,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
 "sed" = (
@@ -53215,7 +52869,7 @@
 "sgW" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "shb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53252,14 +52906,11 @@
 /area/station/security/brig)
 "sjd" = (
 /obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/structure/window/spawner/directional/west,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "sjf" = (
@@ -53420,7 +53071,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "soV" = (
 /turf/open/floor/iron/stairs{
 	icon_state = "stairs_wood";
@@ -54892,7 +54543,7 @@
 	name = "evidence closet 1"
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "tfc" = (
 /obj/structure/table,
 /obj/item/storage/box/hug{
@@ -55960,8 +55611,11 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
 "tMy" = (
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/work)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "tMG" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/bot,
@@ -56154,7 +55808,7 @@
 	name = "evidence closet 2"
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "tSO" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56251,13 +55905,10 @@
 /area/station/security/detectives_office)
 "tXt" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/bed/pod,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "tXv" = (
@@ -56467,7 +56118,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "uca" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -57302,11 +56953,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uGh" = (
-/obj/machinery/hydroponics/constructable,
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/machinery/light/cold/directional/south,
+/obj/structure/loom,
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "uGk" = (
@@ -57599,7 +57250,7 @@
 "uNS" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "uOe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57625,11 +57276,9 @@
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "uOK" = (
-/obj/structure/chair/plastic,
-/obj/machinery/light/cold/directional/east,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/dark/small,
-/area/station/security/prison/work)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "uOM" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -57880,7 +57529,7 @@
 /obj/effect/turf_decal/box/blue,
 /obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/evidence)
 "uVD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58698,10 +58347,12 @@
 	dir = 10
 	},
 /obj/effect/spawner/random/structure/crate,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "vvP" = (
 /obj/machinery/light/small/broken/directional/south,
 /turf/open/floor/plating,
@@ -59126,7 +58777,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "vGT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -59182,7 +58833,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "vIe" = (
 /obj/effect/spawner/liquids_spawner,
 /turf/open/floor/iron/pool/cobble/corner{
@@ -59736,12 +59387,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "wbV" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/table/reinforced/rglass,
 /obj/item/hairbrush,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "wbY" = (
@@ -60403,7 +60051,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "wAO" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -60866,7 +60514,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "wPx" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -60973,7 +60621,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "wRw" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/work)
@@ -61068,16 +60716,7 @@
 /obj/machinery/chem_heater/withbuffer,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "wTu" = (
@@ -61242,21 +60881,12 @@
 /area/station/security/checkpoint/escape)
 "wXA" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "wXT" = (
@@ -61870,13 +61500,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "xtO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/chair/comfy/barber_chair{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/barber)
 "xtV" = (
@@ -62146,7 +61773,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/security/brig)
+/area/station/maintenance/department/security/brig)
 "xDp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62312,16 +61939,6 @@
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "xMa" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Surgery B"
@@ -62330,6 +61947,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/medical/surgery,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/surgery/fore)
 "xMx" = (
@@ -83752,7 +83370,7 @@ aKM
 ofT
 ofT
 ofT
-ofT
+pOz
 xUu
 qwZ
 xNZ
@@ -84980,13 +84598,13 @@ vjN
 pcN
 oyV
 pcN
-rda
-rda
-rda
-rda
-rda
-rda
-rda
+ajx
+ajx
+ajx
+ajx
+ajx
+ajx
+ajx
 xzh
 xzh
 xzh
@@ -85237,13 +84855,13 @@ vjN
 rjn
 kfL
 kDW
-rda
+ajx
 teZ
 kAm
 rhJ
 kpn
 uUW
-rda
+ajx
 xzh
 xzh
 xzh
@@ -85494,13 +85112,13 @@ vjN
 qEg
 lAV
 ukX
-rda
+ajx
 tSe
 oUb
 lPs
 uNS
 uUW
-rda
+ajx
 xzh
 xzh
 xzh
@@ -85751,13 +85369,13 @@ vjN
 fNL
 lAV
 ukX
-rda
+ajx
 cSD
 ere
 lPs
 rhu
 ubW
-rda
+ajx
 xzh
 xzh
 xzh
@@ -86008,13 +85626,13 @@ vjN
 lVV
 lAV
 ukX
-rda
+ajx
 soJ
 soJ
 soJ
 soJ
 soJ
-rda
+ajx
 xzh
 xzh
 xzh
@@ -86265,13 +85883,13 @@ adR
 ulK
 lAV
 fhm
-rda
+ajx
 iTx
 rTR
 qqN
 jmS
 iTx
-rda
+ajx
 xzh
 xzh
 xzh
@@ -86294,7 +85912,7 @@ mPJ
 tnV
 upF
 gmv
-ajx
+qLX
 qLX
 eyr
 aLE
@@ -86522,14 +86140,14 @@ aUl
 ohZ
 gOC
 ukX
-rda
-rda
-rda
-rda
+ajx
+ajx
+ajx
+ajx
 gJN
-rda
-rda
-rda
+ajx
+ajx
+ajx
 xzh
 xzh
 xzh
@@ -87020,10 +86638,10 @@ xzh
 xzh
 loG
 xzh
-adR
-aUl
-aUl
-aUl
+qkP
+hVF
+hVF
+hVF
 adR
 iix
 iVu
@@ -87277,9 +86895,9 @@ xzh
 xzh
 loG
 sUX
-adR
-iVu
-cky
+qkP
+kSH
+uOK
 hIH
 adR
 srD
@@ -87534,9 +87152,9 @@ xzh
 xzh
 cUr
 xzh
-adR
-iVu
-cky
+qkP
+kSH
+uOK
 sgW
 adR
 ehk
@@ -87791,10 +87409,10 @@ xzh
 xzh
 xzh
 xzh
-aUl
-iVu
+hVF
+kSH
 jgC
-iVu
+kSH
 xRQ
 wPx
 pgj
@@ -88048,10 +87666,10 @@ xzh
 xzh
 loG
 xzh
-aUl
-cky
-cky
-iVu
+hVF
+uOK
+uOK
+kSH
 adR
 tdM
 pgj
@@ -88305,10 +87923,10 @@ loG
 xzh
 loG
 sUX
-aUl
+hVF
 hIH
-cky
-iVu
+uOK
+kSH
 adR
 wPx
 iVu
@@ -88562,9 +88180,9 @@ loG
 sUX
 loG
 xzh
-adR
+qkP
 wAw
-qhR
+tMy
 wRv
 adR
 xxX
@@ -88819,7 +88437,7 @@ loG
 xzh
 loG
 sUX
-aUl
+hVF
 eag
 kDQ
 vGP
@@ -89076,10 +88694,10 @@ cUr
 xzh
 loG
 xzh
-aUl
-cky
-qhR
-iVu
+hVF
+uOK
+tMy
+kxm
 wBl
 oGv
 lAZ
@@ -89333,10 +88951,10 @@ cUr
 sUX
 cUr
 xzh
-adR
+qkP
 dIn
-qhR
-qhR
+oZn
+tMy
 jma
 bZk
 lCZ
@@ -89590,7 +89208,7 @@ cUr
 xzh
 loG
 xzh
-adR
+qkP
 mTE
 gNb
 imo
@@ -92414,8 +92032,8 @@ ske
 ske
 aTt
 aTt
-xzh
-xzh
+wRw
+bJc
 aaZ
 xMH
 abN
@@ -92670,9 +92288,9 @@ ske
 xMx
 ske
 mbF
-aTt
-aTt
+dcr
 wRw
+sUX
 aaZ
 rDB
 abN
@@ -92928,8 +92546,8 @@ iky
 ske
 oyo
 eli
-kxm
-kSH
+wRw
+sUX
 aaZ
 aaZ
 abN
@@ -93185,9 +92803,9 @@ sTZ
 ske
 bWn
 hDY
-tMy
-hVF
-qkP
+wRw
+sUX
+loG
 aaZ
 tZm
 abN
@@ -93442,9 +93060,9 @@ kNT
 ske
 kTc
 pGD
-mnh
-uOK
-kSH
+wRw
+sUX
+loG
 aaZ
 syh
 dFh
@@ -93699,7 +93317,7 @@ skP
 ske
 puJ
 wzp
-puJ
+wRw
 wRw
 wRw
 aaZ
@@ -97830,7 +97448,7 @@ afA
 aiX
 aiX
 aiX
-aiX
+mnh
 vvi
 pOR
 anc
@@ -98087,13 +97705,13 @@ afA
 xzh
 aiX
 aiX
-aiX
-aiX
-aiX
-aiX
-aiX
-aiX
-aiX
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
+mnh
 oiB
 oiB
 oiB

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -46171,7 +46171,6 @@
 /obj/item/clothing/accessory/badge/holo/warden,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/machinery/recharger,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "nUe" = (
@@ -48468,6 +48467,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "pon" = (

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -87,7 +87,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_corner"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "aaZ" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
@@ -208,16 +208,10 @@
 /area/station/command/heads_quarters/qm)
 "acv" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/bot_blue,
-/obj/effect/turf_decal/vg_decals/numbers/five,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
-	name = "Cell 5";
-	id = "Cell 5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/turf/open/floor/iron/dark/small,
+/area/station/security/holding_cell)
 "acy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -842,16 +836,14 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/bomb)
 "ajm" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
+	},
+/obj/structure/chair/comfy{
+	color = "#8a3033"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
@@ -914,6 +906,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
@@ -1174,7 +1169,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "amv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -1207,6 +1202,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "amA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "amC" = (
@@ -1336,26 +1332,33 @@
 	dir = 4
 	},
 /obj/structure/chair{
-	name = "Defendant"
+	dir = 8
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "anF" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/coffeepot{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/coffeemaker{
+	pixel_y = 13
 	},
-/obj/structure/cable,
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/coffee_cartridge/bootleg{
+	pixel_x = 8
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "anH" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall/r_wall,
@@ -1366,6 +1369,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "anJ" = (
@@ -1452,6 +1458,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "aoM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "aoN" = (
@@ -1542,13 +1549,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "apB" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Fore Starboard Solars"
@@ -1630,6 +1638,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "aqy" = (
@@ -1761,6 +1772,9 @@
 /area/station/commons/fitness)
 "arr" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "aru" = (
@@ -1873,7 +1887,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "asb" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -1884,11 +1897,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/door/window/left/directional/north,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "asd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance"
@@ -2076,7 +2088,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron/smooth_large,
-/area/station/maintenance/starboard/fore)
+/area/station/hallway/secondary/service)
 "atr" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -2158,7 +2170,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/service/chapel)
 "atP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -2203,6 +2215,9 @@
 /area/station/maintenance/port/fore)
 "atV" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "atW" = (
@@ -2683,8 +2698,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/obj/structure/closet/masks,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -2940,6 +2954,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "axK" = (
@@ -2958,6 +2975,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 4;
 	icon_state = "darkcorner"
@@ -3122,6 +3140,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ayD" = (
@@ -3138,12 +3159,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ayI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/turf/open/floor/iron/dark,
+/area/station/cargo/bitrunning/den)
 "ayJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3225,6 +3247,22 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"azr" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/iron/herringbone,
+/area/station/commons/fitness)
 "azs" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3292,6 +3330,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "azU" = (
@@ -3536,6 +3577,9 @@
 "aAV" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aAW" = (
@@ -3580,6 +3624,9 @@
 "aBf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/carpet,
 /area/station/service/library)
@@ -3669,7 +3716,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "aBC" = (
 /obj/structure/disposalpipe/sorting/mail,
 /obj/effect/turf_decal/tile/neutral{
@@ -3949,6 +3996,9 @@
 	},
 /obj/effect/turf_decal/siding/white,
 /obj/structure/urinal/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aDA" = (
@@ -3957,6 +4007,9 @@
 /area/station/hallway/primary/starboard)
 "aDD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aDG" = (
@@ -4038,6 +4091,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/service/theater)
 "aDT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "aDX" = (
@@ -4272,6 +4326,9 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aFN" = (
@@ -4544,7 +4601,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_half"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "aGI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
@@ -4623,7 +4680,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/area/station/security/checkpoint/customs)
 "aHd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -5634,6 +5691,9 @@
 /area/station/commons/dorms)
 "aLU" = (
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_large"
 	},
@@ -6490,7 +6550,6 @@
 /area/station/hallway/primary/port)
 "aPP" = (
 /obj/machinery/light/directional/west,
-/obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
 	dir = 5
 	},
@@ -6503,6 +6562,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/closet/athletic_mixed,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "aPQ" = (
@@ -7713,6 +7773,9 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/service/library)
 "aVO" = (
@@ -7774,6 +7837,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/service/library)
 "aVZ" = (
@@ -7802,6 +7868,9 @@
 "aWd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/station/service/library)
@@ -7846,7 +7915,6 @@
 "aWr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "aWs" = (
@@ -8203,6 +8271,9 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/service/library)
 "aXv" = (
@@ -8238,7 +8309,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/station/command/heads_quarters/qm)
 "aXP" = (
 /obj/structure/sign/poster/random/directional/west,
 /obj/structure/closet/crate,
@@ -8271,6 +8342,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/carpet,
 /area/station/service/library)
 "aXY" = (
@@ -8278,20 +8352,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "aXZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 9
+	dir = 6
 	},
-/turf/open/floor/carpet,
-/area/station/commons/vacant_room/office)
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "aYc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8875,6 +8947,9 @@
 /area/station/command/heads_quarters/captain)
 "bar" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "bas" = (
@@ -9031,9 +9106,10 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "bbb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bbh" = (
@@ -9535,6 +9611,12 @@
 "bdl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bdm" = (
@@ -9557,9 +9639,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bdp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
+/area/station/hallway/primary/central)
 "bds" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Starboard Primary Hallway 4"
@@ -9672,6 +9756,9 @@
 /area/station/maintenance/aft)
 "bdR" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "bdV" = (
@@ -10505,22 +10592,13 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bhr" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
 /obj/machinery/defibrillator_mount/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bht" = (
@@ -13292,6 +13370,7 @@
 	dir = 9
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "bsv" = (
@@ -14955,19 +15034,10 @@
 /area/station/science/ordnance)
 "bxS" = (
 /obj/machinery/medical_kiosk,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bxT" = (
@@ -15193,16 +15263,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bzh" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/computer/crew,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -15211,6 +15271,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bzm" = (
@@ -15467,18 +15528,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bAq" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bAr" = (
@@ -15751,17 +15803,8 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bBx" = (
@@ -16004,7 +16047,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/medical/chemistry)
 "bCE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16061,16 +16104,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bCL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/medical/cryo)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "bCM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -16078,16 +16117,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bCN" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -16107,24 +16136,16 @@
 	pixel_y = 10
 	},
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bCO" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
 /obj/machinery/defibrillator_mount/directional/south,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "bCP" = (
@@ -16375,14 +16396,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/clipboard,
-/obj/item/pen,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/fax{
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
+	},
+/obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "bDJ" = (
@@ -16443,10 +16462,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
+/obj/machinery/vending/medical{
+	pixel_x = -2
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
@@ -16513,19 +16530,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
 "bEh" = (
-/obj/machinery/vending/medical{
-	pixel_x = -2
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bEi" = (
@@ -16550,20 +16555,11 @@
 /area/station/medical/storage)
 "bEk" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Medbay Storage";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bEl" = (
@@ -16578,17 +16574,8 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "bEn" = (
@@ -16737,6 +16724,9 @@
 /obj/effect/landmark/navigate_destination,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
@@ -16946,7 +16936,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/service/janitor,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/service/janitor)
 "bFv" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -17865,8 +17855,8 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -17993,6 +17983,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -18694,7 +18687,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/engineering/atmos)
 "bLR" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 1
@@ -19264,6 +19257,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"bNU" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "bNV" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
@@ -19364,9 +19363,7 @@
 /area/station/tcommsat/computer)
 "bOq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bOr" = (
@@ -20868,6 +20865,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"bWm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/aft)
 "bWn" = (
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/newscaster/directional/north,
@@ -21058,6 +21061,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/item/wrench/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "bWZ" = (
@@ -22699,7 +22703,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/engine_equipment,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/engineering/main)
 "cfF" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/effect/turf_decal/stripes/line{
@@ -23103,6 +23107,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "chV" = (
@@ -23413,6 +23420,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "cjI" = (
@@ -23657,6 +23667,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "clx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "cly" = (
@@ -23760,6 +23773,9 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cmw" = (
@@ -24041,10 +24057,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cpE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cpI" = (
@@ -24320,7 +24337,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "cqP" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/smooth_large,
@@ -24390,6 +24407,9 @@
 "cri" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -26586,6 +26606,9 @@
 "cBT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cBU" = (
@@ -27411,7 +27434,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "cGF" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
@@ -27721,15 +27743,14 @@
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "cKC" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/turf/open/floor/plating,
+/area/station/security/courtroom)
 "cKF" = (
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood/parquet,
@@ -27937,7 +27958,6 @@
 /area/station/maintenance/starboard/aft)
 "cOi" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
@@ -28321,6 +28341,9 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cTJ" = (
@@ -28329,6 +28352,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "cTK" = (
@@ -28533,7 +28562,6 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
 "dch" = (
-/obj/structure/cable,
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -28576,6 +28604,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
@@ -28646,10 +28677,6 @@
 /obj/machinery/door/window/left/directional/east{
 	name = "Medbay Delivery";
 	req_access = list("medical")
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "Medbay"
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/yellow,
@@ -28924,9 +28951,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_half"
 	},
@@ -28950,6 +28974,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
+"dpi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "dpD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -28966,7 +28997,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/medbay/central)
 "dqu" = (
 /obj/structure/window/spawner/directional/west,
 /turf/open/floor/carpet/blue,
@@ -29008,6 +29039,15 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"drT" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "drX" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
 	dir = 1
@@ -29244,6 +29284,9 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
+"dxX" = (
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "dyd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -29394,6 +29437,9 @@
 /area/station/science/cytology)
 "dEC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -29888,6 +29934,10 @@
 	icon_state = "L4"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "dSO" = (
@@ -30067,12 +30117,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	color = "#9FED58";
 	name = "green line"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
@@ -30443,7 +30493,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/holding_cell)
 "ejB" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/brown/double,
@@ -30586,7 +30636,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "enW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
@@ -30862,7 +30911,7 @@
 	name = "Cell 5 Locker"
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/holding_cell)
 "ezJ" = (
 /obj/structure/railing{
 	name = "wooden railing";
@@ -30918,9 +30967,6 @@
 /area/station/maintenance/aft)
 "eAX" = (
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/reagent_containers/cup/bottle/epinephrine{
 	pixel_x = -1;
 	pixel_y = 2
@@ -30944,6 +30990,7 @@
 	},
 /obj/structure/closet/secure_closet/warden,
 /obj/item/gun/energy/laser,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "eCU" = (
@@ -31062,6 +31109,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"eFA" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar)
 "eFK" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/random/contraband/armory,
@@ -31132,7 +31186,6 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "eHZ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
 	},
@@ -31356,8 +31409,8 @@
 	name = "green line"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
@@ -31846,9 +31899,6 @@
 /turf/open/space/basic,
 /area/station/solars/port/aft)
 "few" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	pixel_y = -22
 	},
@@ -32461,6 +32511,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/gateway)
+"fAO" = (
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/turf/open/floor/plating,
+/area/station/security/courtroom)
 "fBf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -32487,9 +32543,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/station/cargo/bitrunning/den)
 "fBp" = (
@@ -32535,9 +32588,6 @@
 	},
 /area/station/hallway/secondary/service)
 "fDM" = (
-/obj/structure/chair/comfy{
-	color = "#8a3033"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -32545,6 +32595,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "fDX" = (
@@ -32557,6 +32608,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/lawoffice)
+"fEE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "fEM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/trash_pile,
@@ -32793,6 +32850,10 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"fLV" = (
+/obj/structure/table,
+/turf/open/floor/iron/dark/small,
+/area/station/security/holding_cell)
 "fMb" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -32989,18 +33050,18 @@
 "fSL" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/holding_cell)
 "fSN" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "fTd" = (
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
 	name = "Isolation Cell"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "fTk" = (
@@ -33058,6 +33119,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "fUJ" = (
@@ -33086,7 +33148,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_half"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "fVk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -33173,7 +33235,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "fYk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
@@ -33412,6 +33473,10 @@
 	icon_state = "L6"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ggx" = (
@@ -33502,7 +33567,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "gjD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/railing,
 /obj/effect/turf_decal/tile/neutral{
@@ -33575,10 +33639,6 @@
 /turf/closed/wall,
 /area/station/service/chapel)
 "glK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=AIE";
-	location = "AftH"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33699,6 +33759,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "gou" = (
@@ -33885,23 +33946,9 @@
 	},
 /area/station/holodeck/rec_center)
 "gua" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/door/airlock/corporate{
-	name = "Court Entrance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/obj/structure/cable,
-/turf/open/floor/iron/dark{
-	icon_state = "textured_dark_large"
-	},
-/area/station/maintenance/fore/lesser)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness)
 "gui" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -33926,8 +33973,12 @@
 /area/station/engineering/break_room)
 "guI" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/warden)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "gva" = (
 /obj/structure/railing{
 	dir = 1
@@ -34409,6 +34460,9 @@
 "gJP" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/keycard/library,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "gKq" = (
@@ -34518,25 +34572,10 @@
 /area/station/ai_monitored/security/armory)
 "gOB" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/structure/table/reinforced,
-/obj/item/coffee_cartridge/bootleg{
-	pixel_x = 8
-	},
-/obj/item/coffee_cartridge/bootleg{
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/machinery/coffeemaker{
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/cup/coffeepot{
-	pixel_x = -5;
-	pixel_y = 3
-	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "gOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34622,6 +34661,10 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gRp" = (
@@ -34687,7 +34730,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "gSC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -34698,6 +34741,10 @@
 "gSY" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gTG" = (
@@ -35036,7 +35083,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_half"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "hdS" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -35057,6 +35104,13 @@
 /mob/living/basic/pet/fox/renault,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"heh" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "hei" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -35174,7 +35228,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "hgn" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -35337,17 +35391,8 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "hjX" = (
@@ -35696,7 +35741,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "hwz" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron/smooth_large,
@@ -35873,6 +35918,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "hAX" = (
@@ -36027,10 +36075,13 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "hEJ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -36195,9 +36246,23 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "hKq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/door/airlock/corporate{
+	name = "Court Entrance"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/fore/lesser)
+/turf/open/floor/iron/dark{
+	icon_state = "textured_dark_large"
+	},
+/area/station/security/courtroom)
 "hKu" = (
 /obj/machinery/modular_computer/preset/civilian,
 /obj/machinery/posialert{
@@ -36392,7 +36457,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/holding_cell)
 "hQh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -36415,6 +36480,15 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
+"hQI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "hQT" = (
 /obj/structure/railing{
 	name = "wooden railing";
@@ -36654,7 +36728,7 @@
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/holding_cell)
 "iav" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -36756,11 +36830,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "idf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/service/chapel)
@@ -37116,6 +37194,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "imk" = (
@@ -37368,11 +37449,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "ivV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/area/station/cargo/miningdock)
 "ivY" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -37456,6 +37537,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "izx" = (
@@ -37668,6 +37750,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "iEJ" = (
@@ -37852,9 +37935,11 @@
 /area/station/security/execution)
 "iKC" = (
 /obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/transfer)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "iLy" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -37932,6 +38017,13 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen)
+"iNr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard/fore)
 "iOA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -38077,7 +38169,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard)
+/area/station/science/breakroom)
 "iTo" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/light/small/directional/east,
@@ -38153,6 +38245,12 @@
 "iVu" = (
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"iVU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "iWe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -38292,11 +38390,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jbp" = (
+/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 8
 	},
-/turf/closed/wall,
-/area/station/commons/toilet)
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "jbq" = (
 /obj/structure/kitchenspike,
 /obj/item/stack/sheet/leather,
@@ -38439,16 +38538,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "jgM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags{
 	pixel_x = 3;
@@ -38458,6 +38547,7 @@
 /obj/item/hand_labeler,
 /obj/item/gun/syringe,
 /obj/item/gun/syringe,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "jgZ" = (
@@ -38567,6 +38657,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "jkh" = (
@@ -39171,6 +39264,9 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jAi" = (
 /obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "jAj" = (
@@ -39208,7 +39304,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/holding_cell)
 "jBs" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -39366,6 +39462,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "jGC" = (
@@ -39499,6 +39596,12 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"jLo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "jLV" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -39904,6 +40007,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "Medbay"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay)
 "jWJ" = (
@@ -39914,6 +40021,16 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"jXg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "jXl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -40072,7 +40189,7 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/medical/cryo)
 "kce" = (
 /turf/open/floor/wood/large,
 /area/station/service/lawoffice)
@@ -40084,22 +40201,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "kcL" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
 /obj/structure/cable,
 /obj/machinery/defibrillator_mount/directional/north,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "kcN" = (
@@ -40234,6 +40342,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
@@ -40344,22 +40455,13 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/security/prison/safe)
 "klp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/storage/box/gloves{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /obj/item/storage/box/masks,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "klw" = (
@@ -40388,7 +40490,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "knw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -40545,6 +40647,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "krb" = (
@@ -40723,21 +40828,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "kxj" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
 /obj/machinery/defibrillator_mount/directional/north,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "kxm" = (
@@ -40995,6 +41091,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "kDQ" = (
@@ -41187,6 +41286,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/aft)
+"kKr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal)
 "kKD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41265,22 +41376,13 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/door/window/right/directional/west{
 	name = "First-Aid Supplies";
 	red_alert_access = 1;
 	req_access = list("medical")
 	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "kNl" = (
@@ -42381,6 +42483,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/medical/break_room)
+"lzM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "lzS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -42465,7 +42574,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "lBD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/food/cornchips/random,
@@ -42539,13 +42647,13 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "lEE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -42607,6 +42715,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/general,
 /turf/open/floor/iron,
 /area/station/science/explab)
+"lGj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/lesser)
 "lGD" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/airalarm/directional/south,
@@ -42674,6 +42790,9 @@
 "lIJ" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Shower"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/white/small{
 	icon_state = "textured_white_large"
@@ -42920,7 +43039,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/commons/dorms)
 "lOw" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -43143,10 +43262,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/closet/boxinggloves,
 /obj/structure/railing{
 	dir = 5
 	},
+/obj/structure/closet/masks,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "lVy" = (
@@ -43558,11 +43677,10 @@
 	},
 /area/station/service/hydroponics/garden)
 "miY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "mje" = (
@@ -43614,6 +43732,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"mmj" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron/dark/small,
+/area/station/security/holding_cell)
 "mmW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43676,6 +43799,18 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"mpW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_blue,
+/obj/effect/turf_decal/vg_decals/numbers/five,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	name = "Cell 5";
+	id = "Cell 5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "mql" = (
 /obj/item/screwdriver{
 	pixel_y = 10
@@ -43994,21 +44129,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mCo" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze{
 	pixel_x = 8
 	},
 /obj/item/clothing/neck/stethoscope,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "mCu" = (
@@ -44254,19 +44380,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "mLY" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/clothing/neck/stethoscope,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "mMO" = (
@@ -44530,7 +44647,11 @@
 /area/station/ai_monitored/command/nuke_storage)
 "mUK" = (
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "mUV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -44711,7 +44832,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_half"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "naY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -44754,6 +44875,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nce" = (
@@ -45551,7 +45673,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "nCu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -45615,7 +45737,7 @@
 /area/station/service/chapel)
 "nCT" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "nCU" = (
@@ -45875,6 +45997,9 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/bar)
+"nIH" = (
+/turf/closed/wall/r_wall,
+/area/station/security/holding_cell)
 "nIN" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -46018,9 +46143,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "nMw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/quantum_server,
 /obj/effect/turf_decal/bot,
@@ -46068,6 +46190,13 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"nOy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/aft)
 "nOI" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/structure/railing{
@@ -46161,6 +46290,10 @@
 /area/station/security/detectives_office)
 "nQD" = (
 /obj/structure/sign/warning/pods/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -46444,6 +46577,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -46760,14 +46896,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "oiB" = (
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/access/any/cent_com/rep_or_captain,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/fore/lesser)
+/turf/closed/wall/r_wall,
+/area/station/security/courtroom)
 "oju" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -46896,6 +47026,7 @@
 "ooO" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "opE" = (
@@ -46936,7 +47067,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/closet/athletic_mixed,
+/obj/structure/closet/masks,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "oqt" = (
@@ -47059,7 +47190,7 @@
 	icon_state = "textured_dark_corner";
 	dir = 8
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "oth" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Incoming Mail";
@@ -47201,6 +47332,10 @@
 "ouV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobiomain";
+	name = "Containment Blast Door"
+	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "ova" = (
@@ -47240,6 +47375,13 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/item/clipboard,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
+/obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "owk" = (
@@ -47804,7 +47946,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "oOL" = (
 /obj/machinery/firealarm/directional/east,
 /obj/item/radio/intercom/directional/north,
@@ -48800,9 +48942,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pvi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage{
 	pixel_x = -4;
@@ -48818,7 +48957,6 @@
 	},
 /area/station/service/bar)
 "pvj" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
 	dir = 6
 	},
@@ -48829,6 +48967,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/closet/boxinggloves,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "pvk" = (
@@ -48984,8 +49123,8 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden/abandoned)
@@ -49057,6 +49196,9 @@
 /obj/item/reagent_containers/cup/bucket{
 	pixel_y = 6;
 	pixel_x = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
@@ -49146,14 +49288,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "pGo" = (
-/obj/structure/window/reinforced/spawner/directional/south{
-	pixel_y = -4
-	},
-/obj/item/kirbyplants/synthetic/plant27,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "pGD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49442,6 +49580,10 @@
 /area/station/security/detectives_office)
 "pQf" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "pQq" = (
@@ -49493,7 +49635,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/security/interrogation)
+/area/station/security/holding_cell)
 "pSb" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -49644,24 +49786,15 @@
 /area/station/security/prison)
 "pZa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/recharge_station,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "pZN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "qac" = (
@@ -50112,10 +50245,13 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
 	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "qpx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -50644,6 +50780,10 @@
 	icon_state = "L2"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qEZ" = (
@@ -50687,7 +50827,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "qGo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/railing{
 	dir = 1
@@ -50739,16 +50878,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "qHw" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -50761,6 +50890,7 @@
 /obj/item/reagent_containers/syringe,
 /obj/machinery/light/directional/east,
 /obj/structure/sign/eyechart/directional/east,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "qHL" = (
@@ -50872,7 +51002,6 @@
 "qLx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qLV" = (
@@ -51187,6 +51316,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -51212,6 +51344,10 @@
 	icon_state = "L7"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qWu" = (
@@ -51288,10 +51424,7 @@
 	id_tag = null;
 	name = "Medbay Foyer"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qYj" = (
@@ -51316,6 +51449,10 @@
 	icon_state = "L10"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "qZe" = (
@@ -51396,7 +51533,6 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance)
 "rcV" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -51409,6 +51545,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/structure/closet/athletic_mixed,
 /turf/open/floor/iron/herringbone,
 /area/station/commons/fitness)
 "rda" = (
@@ -51728,6 +51865,7 @@
 /area/station/security/courtroom)
 "rpn" = (
 /obj/structure/bed/maint,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "rps" = (
@@ -51800,10 +51938,18 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 10
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "rrc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -51846,7 +51992,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/area/station/medical/cryo)
 "rrG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -51964,6 +52110,16 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/lockers)
+"ryc" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "ryq" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -52555,6 +52711,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "rSM" = (
@@ -52671,10 +52830,21 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
+"rXk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rXJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
 "rYd" = (
@@ -53376,7 +53546,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "ssN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -53489,6 +53659,10 @@
 "swA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "swD" = (
@@ -53766,6 +53940,10 @@
 	icon_state = "L8"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "sGs" = (
@@ -54002,6 +54180,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
 "sMx" = (
@@ -54123,6 +54302,10 @@
 "sPz" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "sPI" = (
@@ -54163,10 +54346,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
 /area/station/service/chapel)
+"sRx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "sRy" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -54418,9 +54608,26 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
+"sYJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "sYU" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "sYX" = (
@@ -54500,6 +54707,9 @@
 /area/station/service/barber)
 "taC" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "taR" = (
@@ -54842,7 +55052,7 @@
 	icon_state = "textured_dark_corner";
 	dir = 1
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "tjy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -54947,7 +55157,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "tly" = (
 /obj/machinery/computer/records/security,
 /turf/open/floor/iron/dark,
@@ -55402,6 +55612,9 @@
 /area/station/maintenance/starboard/fore)
 "tAe" = (
 /obj/effect/landmark/start/bitrunner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "tAm" = (
@@ -55524,6 +55737,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tEN" = (
@@ -55703,7 +55919,7 @@
 	},
 /obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/holding_cell)
 "tLv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -56135,6 +56351,12 @@
 "tZS" = (
 /obj/effect/landmark/start/bitrunner,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
 "tZV" = (
@@ -56214,6 +56436,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/service/library)
 "ubJ" = (
@@ -56523,6 +56748,9 @@
 "upr" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "upE" = (
@@ -56533,7 +56761,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/holding_cell)
 "upF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -56774,6 +57002,9 @@
 	name = "Library"
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "uxs" = (
@@ -56791,6 +57022,9 @@
 	},
 /obj/structure/sink/directional/south,
 /obj/structure/mirror/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
 "uyb" = (
@@ -56918,7 +57152,6 @@
 /area/station/commons/storage/emergency/port)
 "uAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "uBi" = (
@@ -57025,10 +57258,11 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "uEH" = (
-/obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/security/courtroom)
 "uEO" = (
@@ -57052,6 +57286,9 @@
 /area/station/command/gateway)
 "uFA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/service/library)
 "uFU" = (
@@ -57073,12 +57310,13 @@
 /turf/open/floor/grass,
 /area/station/security/prison/garden)
 "uGk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_large"
 	},
@@ -57118,9 +57356,6 @@
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "uHE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/cryopod{
 	dir = 1
 	},
@@ -57213,9 +57448,8 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uJU" = (
@@ -57343,11 +57577,10 @@
 	},
 /area/station/service/bar)
 "uNp" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/holding_cell)
 "uNE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -58121,14 +58354,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "vki" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "vkj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -58186,7 +58417,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "vln" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
 "vlS" = (
@@ -58357,6 +58588,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "vro" = (
@@ -58773,6 +59005,10 @@
 	icon_state = "L14"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vEN" = (
@@ -58876,14 +59112,14 @@
 /area/station/science/lab)
 "vGE" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/item/kirbyplants/synthetic/plant27,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "vGP" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "Shooting Range"
@@ -59153,20 +59389,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "vOV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/chair/comfy{
-	color = "#8a3033";
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/dark/smooth_large{
-	icon_state = "textured_dark_half"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
 /area/station/service/bar)
 "vPP" = (
 /obj/effect/turf_decal/tile/blue{
@@ -59678,6 +59903,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"wiY" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "wkp" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/structure/cable,
@@ -59828,7 +60065,7 @@
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "wqH" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/musician/piano{
@@ -59919,6 +60156,9 @@
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/white/small,
 /area/station/commons/toilet)
@@ -60050,6 +60290,10 @@
 	name = "Central Access"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wxY" = (
@@ -60066,6 +60310,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wyp" = (
@@ -60269,7 +60514,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "wET" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/random/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -60282,6 +60526,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "wFX" = (
@@ -60683,18 +60930,8 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/general,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/area/station/science/explab)
 "wQK" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -60704,6 +60941,7 @@
 	},
 /obj/item/reagent_containers/syringe,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/medbay/central)
 "wQY" = (
@@ -60723,7 +60961,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/service/library)
 "wRn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60925,8 +61163,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "wVC" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/storage)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=AIE";
+	location = "AftH"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "wVD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -61254,7 +61499,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "xgh" = (
@@ -61425,6 +61669,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"xnv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard/aft)
 "xnO" = (
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
@@ -61740,6 +61991,9 @@
 /obj/machinery/mineral/stacking_unit_console{
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "xxM" = (
@@ -61992,13 +62246,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_corner";
 	dir = 4
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -62523,7 +62777,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/service/chapel/office)
 "xXd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -62597,16 +62851,18 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "yaJ" = (
-/obj/structure/chair{
-	name = "Defendant"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/door/window/left/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
-/area/station/maintenance/fore/lesser)
+/area/station/security/courtroom)
 "yaT" = (
 /obj/structure/sign/warning/no_smoking{
 	pixel_x = -25
@@ -70889,8 +71145,8 @@ xzh
 xzh
 xzh
 arB
-awZ
-ayl
+hQI
+jLo
 aUN
 awW
 xzh
@@ -71146,7 +71402,7 @@ xzh
 xzh
 xzh
 arB
-jVc
+ryc
 ayl
 ayk
 awW
@@ -71403,8 +71659,8 @@ uRx
 aDO
 uRx
 arB
-awZ
-ayl
+wiY
+iVU
 ayk
 awW
 xzh
@@ -71660,7 +71916,7 @@ asE
 fWj
 asE
 arB
-gbd
+sYJ
 ayl
 lIm
 awW
@@ -71917,7 +72173,7 @@ baC
 auP
 iEJ
 arB
-awZ
+wiY
 ayl
 aUN
 awW
@@ -72431,7 +72687,7 @@ auP
 gfa
 jly
 lOw
-ayl
+bbb
 ayk
 awW
 aAD
@@ -72688,7 +72944,7 @@ awW
 awW
 jly
 ayl
-ayl
+bbb
 ayk
 beK
 auP
@@ -72945,7 +73201,7 @@ baF
 azz
 khB
 ayl
-ayl
+bbb
 ayk
 asE
 awW
@@ -73202,7 +73458,7 @@ cqr
 ayl
 ayl
 ayl
-ayl
+bbb
 kdI
 azz
 aAF
@@ -73459,7 +73715,7 @@ cwT
 ayl
 ayl
 ayl
-ayl
+bbb
 ayl
 ayl
 aAE
@@ -73716,7 +73972,7 @@ cxY
 ayl
 ayl
 ayl
-ayl
+bbb
 ayl
 ayl
 bgi
@@ -73973,7 +74229,7 @@ cyb
 azA
 aQH
 ayl
-ayl
+bbb
 ayn
 azA
 bgh
@@ -74230,7 +74486,7 @@ awW
 awW
 jly
 ayl
-ayl
+bbb
 hGN
 asE
 awW
@@ -74487,7 +74743,7 @@ auP
 fUa
 jly
 ayl
-ayl
+bbb
 ayk
 beL
 auP
@@ -74744,7 +75000,7 @@ awW
 awW
 lCi
 ayl
-ayl
+bbb
 ayk
 awW
 aAD
@@ -75000,8 +75256,8 @@ xzh
 awW
 hFg
 khB
-ayl
-ayl
+sRx
+bbb
 kdI
 azB
 awW
@@ -75259,7 +75515,7 @@ ivv
 ayl
 ayl
 bbb
-ayl
+iVU
 beN
 arB
 xzh
@@ -76797,7 +77053,7 @@ aPx
 czK
 aUQ
 aWr
-aXZ
+aBs
 aUQ
 czK
 bdt
@@ -77319,8 +77575,8 @@ beO
 beU
 bgk
 bhL
-bjc
-cAF
+kKr
+fEE
 blV
 beO
 xzh
@@ -79335,11 +79591,11 @@ akB
 usN
 akB
 amA
-akB
+lzM
 anI
-aol
-aol
-aol
+aXZ
+aXZ
+aXZ
 ajK
 alU
 hKJ
@@ -79854,14 +80110,14 @@ alR
 aom
 aoX
 apP
-aol
-aol
-aol
-aol
-aol
-aol
-aol
-aol
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 alU
 alU
 azF
@@ -80118,8 +80374,8 @@ alU
 alU
 alU
 alU
-aol
-aol
+aXZ
+aXZ
 aAV
 alU
 aDh
@@ -82502,7 +82758,7 @@ gkk
 cAK
 cfw
 cgC
-ciS
+bWm
 ciS
 cfw
 xzh
@@ -82759,7 +83015,7 @@ bCq
 bCq
 cfw
 cgB
-chN
+nOy
 nRA
 cfw
 xzh
@@ -83273,7 +83529,7 @@ vLX
 yaq
 bCq
 cgD
-qhN
+guI
 vLX
 cjI
 bLv
@@ -83530,7 +83786,7 @@ vLX
 iOA
 bCq
 fcO
-qhN
+guI
 vLX
 bLu
 bLv
@@ -83786,8 +84042,8 @@ mjq
 lrN
 bCq
 bCq
-qhN
-qhN
+guI
+guI
 vLX
 jco
 bCq
@@ -84277,7 +84533,7 @@ izb
 spl
 bGi
 bHy
-byE
+bzY
 bKj
 bGi
 xzh
@@ -84814,7 +85070,7 @@ kOB
 otQ
 vLX
 bCq
-bUt
+dpi
 bCq
 bCq
 bCq
@@ -85052,7 +85308,7 @@ tAe
 bsb
 qhp
 kRc
-tZS
+ayI
 nMw
 bCq
 gzL
@@ -85071,7 +85327,7 @@ vLX
 vLX
 dCG
 bCq
-qhN
+guI
 bLv
 xzh
 sUX
@@ -85305,7 +85561,7 @@ byE
 bzY
 byE
 bEQ
-byE
+ivV
 xto
 qhp
 fBm
@@ -85328,7 +85584,7 @@ tbr
 nDW
 suK
 bCq
-qhN
+guI
 bLv
 sUX
 wba
@@ -85585,7 +85841,7 @@ bCq
 bCq
 bCq
 bCq
-qhN
+guI
 bLv
 xzh
 wba
@@ -85842,7 +86098,7 @@ anq
 iiB
 wqq
 nHF
-qhN
+guI
 bLv
 xzh
 wba
@@ -86099,7 +86355,7 @@ vci
 vkx
 jEc
 nHF
-bUt
+dpi
 bLv
 xzh
 wba
@@ -86356,7 +86612,7 @@ vci
 vkx
 jEc
 nHF
-qhN
+guI
 bLv
 xzh
 wba
@@ -86530,11 +86786,11 @@ hGP
 nbg
 jyS
 btn
-rda
-rda
-rda
-rda
-rda
+nIH
+nIH
+nIH
+nIH
+nIH
 sUX
 sUX
 sUX
@@ -86613,7 +86869,7 @@ gmF
 eNP
 tlT
 nHF
-qhN
+guI
 bCq
 xzh
 wba
@@ -86787,11 +87043,11 @@ qff
 nbg
 nbg
 eXh
-omS
+uNp
 fSL
 iar
 hPH
-rda
+nIH
 xzh
 xzh
 xzh
@@ -86870,7 +87126,7 @@ wqq
 vVc
 vOr
 bCq
-bUt
+dpi
 bCq
 sUX
 wba
@@ -87048,7 +87304,7 @@ pRD
 ejj
 ejj
 hPH
-rda
+nIH
 xzh
 xzh
 xzh
@@ -87127,7 +87383,7 @@ bCq
 bCq
 bCq
 bCq
-qhN
+guI
 bCq
 xzh
 sUX
@@ -87301,7 +87557,7 @@ nYG
 emh
 nbg
 gFx
-omS
+uNp
 fSL
 jBb
 hPH
@@ -87558,10 +87814,10 @@ xSO
 qWx
 nbg
 wYt
-aiX
-aiX
-aiX
-aiX
+nIH
+nIH
+nIH
+nIH
 oyd
 sKh
 leH
@@ -87593,7 +87849,7 @@ aJq
 aJq
 aJq
 lfF
-aJq
+bdp
 bBi
 aRh
 dMb
@@ -87815,8 +88071,8 @@ ici
 gdz
 nbg
 rST
-vad
-hkA
+fLV
+uNp
 tLn
 upE
 oyd
@@ -87842,20 +88098,20 @@ aJq
 bUm
 izp
 cpE
-bBi
-bBi
-bBi
+cpE
+cpE
+cpE
 gSY
-bBi
-bBi
-bBi
-bBi
-bBi
+cpE
+cpE
+cpE
+cpE
+cpE
 sPz
-bBi
+cpE
 swA
-uAz
-ivV
+cpE
+aJg
 iCx
 bjx
 aTh
@@ -88073,9 +88329,9 @@ qff
 nbg
 nbg
 acv
-ogD
-qUT
-hkA
+mpW
+bNU
+dxX
 oyd
 jJd
 pQc
@@ -88107,7 +88363,7 @@ aJq
 aYl
 aYl
 aYl
-aYl
+jbp
 aYl
 aYl
 svg
@@ -88329,9 +88585,9 @@ oZs
 ogT
 nbg
 qff
-vad
+mmj
 uNp
-dCr
+jXg
 ezH
 oyd
 tgv
@@ -88586,10 +88842,10 @@ omS
 rda
 sWs
 omS
-aiX
-aiX
-aiX
-aiX
+nIH
+nIH
+nIH
+nIH
 oyd
 ata
 vEV
@@ -89381,7 +89637,7 @@ bub
 anQ
 gUK
 lfF
-ayI
+cpE
 sRO
 aJn
 xzh
@@ -89637,9 +89893,9 @@ kWK
 kWK
 anQ
 mys
-aJq
-bBi
-aOE
+uAz
+cpE
+drT
 aJn
 xzh
 aPR
@@ -89895,7 +90151,7 @@ tzt
 wJQ
 ayL
 aJq
-bBi
+cpE
 aOE
 aJn
 xzh
@@ -90152,7 +90408,7 @@ ayL
 ayL
 ayL
 wAO
-bBi
+cpE
 aOE
 aJn
 xzh
@@ -90923,7 +91179,7 @@ ayL
 aJn
 aJn
 aJq
-bBi
+cpE
 aOE
 aPS
 oCj
@@ -91948,8 +92204,8 @@ sYU
 pQf
 pQf
 wwV
-bBi
-bBi
+rXk
+rXk
 qWq
 sGk
 aOE
@@ -92000,7 +92256,7 @@ cau
 cau
 cau
 cau
-cau
+wVC
 cau
 doj
 nte
@@ -92979,7 +93235,7 @@ cvP
 aJn
 aJn
 aJq
-bBi
+cpE
 aOE
 aPS
 mDB
@@ -93197,7 +93453,7 @@ eFK
 nsb
 avB
 eHZ
-guI
+vEA
 cml
 vEA
 cGF
@@ -94221,7 +94477,7 @@ lye
 qTa
 wRw
 dOw
-bPB
+vln
 bgq
 agn
 fHL
@@ -95545,7 +95801,7 @@ aAh
 oWE
 cFF
 hwE
-jbp
+aAh
 aDu
 aAh
 ioJ
@@ -96046,7 +96302,7 @@ rrb
 hKq
 fDM
 uEH
-uIw
+ajp
 arG
 nQe
 ajo
@@ -96284,7 +96540,7 @@ uww
 hyB
 mub
 pgv
-iKC
+uww
 afA
 qEg
 cpc
@@ -96300,10 +96556,10 @@ hfM
 aaU
 xHD
 anF
-gua
+oiB
 ajm
 miY
-ajp
+seE
 cwF
 fFe
 ajo
@@ -96557,7 +96813,7 @@ oOI
 fUX
 nas
 gOB
-aiA
+fAO
 mRn
 vlf
 ahn
@@ -96814,9 +97070,9 @@ knr
 aGH
 nas
 vGE
-aiA
 oiB
-aiA
+oiB
+oiB
 aiA
 aiA
 aiA
@@ -97073,8 +97329,8 @@ hdP
 amr
 asb
 lEl
-mUK
-atV
+cKC
+lGj
 gJP
 atV
 mUK
@@ -97330,7 +97586,7 @@ tji
 pGo
 yaJ
 apu
-aiA
+oiB
 aiA
 aiA
 aiA
@@ -97587,7 +97843,7 @@ nCm
 cqO
 anD
 qps
-aiA
+oiB
 otE
 gsX
 gsX
@@ -97838,13 +98094,13 @@ aiX
 aiX
 aiX
 aiX
-aiA
-aiA
-aiA
-aiA
-aiA
-aiA
-aiA
+oiB
+oiB
+oiB
+oiB
+oiB
+oiB
+oiB
 fjj
 eba
 eba
@@ -98098,7 +98354,7 @@ hCl
 fpc
 aPP
 rcV
-rcV
+azr
 pvj
 mPD
 ihj
@@ -98120,8 +98376,8 @@ dDa
 mCu
 doM
 pvi
-vOV
-lCO
+aIT
+eFA
 ezJ
 wqH
 sdf
@@ -98378,7 +98634,7 @@ mCu
 cle
 vaD
 abw
-lCO
+vOV
 qNT
 ubs
 fjc
@@ -98867,9 +99123,9 @@ rzf
 dch
 gjD
 qGo
-mKW
-mKW
-mKW
+gua
+gua
+gua
 enW
 mKW
 gxj
@@ -99678,10 +99934,10 @@ hAO
 naY
 qjL
 qLx
-cKC
+hMe
 eAX
-qLx
-qLx
+bit
+bit
 qYe
 boc
 bqX
@@ -99951,7 +100207,7 @@ fBp
 bCS
 bfG
 lOZ
-vki
+lOZ
 kbG
 rrA
 bzs
@@ -100206,7 +100462,7 @@ bxS
 bzh
 bAs
 dpI
-bCL
+sxQ
 bxO
 fGg
 nsl
@@ -104267,7 +104523,7 @@ ane
 cxN
 ane
 aoM
-ane
+iNr
 aqw
 arr
 arr
@@ -104316,10 +104572,10 @@ lHs
 bux
 bsI
 bsM
-wVC
-wVC
-wVC
-wVC
+bsM
+bsM
+bsM
+bsM
 bsM
 bHa
 xSj
@@ -105357,7 +105613,7 @@ bkz
 bAW
 bMi
 bIQ
-mdh
+ylY
 cfo
 ohb
 bJN
@@ -105614,7 +105870,7 @@ qAp
 bAW
 bID
 bIR
-mdh
+ylY
 xzr
 dnc
 bJN
@@ -105840,7 +106096,7 @@ aVN
 uFA
 bar
 uxl
-bdp
+bci
 dYh
 bfU
 bhu
@@ -105871,7 +106127,7 @@ iiD
 bMk
 bIO
 bIT
-mdh
+ylY
 xzr
 dnc
 bJN
@@ -106128,7 +106384,7 @@ bMi
 bAW
 bID
 bIR
-mdh
+ylY
 yck
 dnc
 bJN
@@ -106385,7 +106641,7 @@ bMi
 bAW
 bMi
 nxx
-bJN
+bDb
 mdh
 rjh
 bJN
@@ -106661,7 +106917,7 @@ eQV
 bMi
 bMi
 bMi
-mdh
+ylY
 sUX
 cOT
 fif
@@ -107150,8 +107406,8 @@ bEo
 vwd
 vwd
 vwd
-bvK
-bvK
+vwd
+vwd
 bmv
 iLK
 rzA
@@ -107175,7 +107431,7 @@ lse
 bMi
 bMi
 bMi
-mdh
+ylY
 sUX
 cOT
 pxV
@@ -107408,12 +107664,12 @@ bCj
 bHe
 uTD
 kHN
-bvK
+vwd
 bnB
 dQy
 bMi
 bNp
-bJN
+bDb
 jRs
 txJ
 bJN
@@ -107665,12 +107921,12 @@ bIC
 bEc
 aWt
 hnE
-bvK
+vwd
 bnT
 dQy
 bMi
 bLe
-bJN
+bDb
 bJN
 bJN
 bJN
@@ -107922,12 +108178,12 @@ bCX
 jDF
 cvi
 kfh
-bvK
+vwd
 boP
 dQy
 bMi
 bNr
-bJN
+bDb
 bVk
 nlQ
 bJN
@@ -108179,7 +108435,7 @@ bDj
 bDY
 uxs
 neV
-bvK
+vwd
 bsd
 dQy
 blq
@@ -108436,12 +108692,12 @@ bDf
 aQC
 bGY
 hAX
-bvK
+vwd
 bsd
 dQy
 bMi
 bPJ
-bJN
+bDb
 czb
 dxm
 bJN
@@ -108693,22 +108949,22 @@ bDc
 bvJ
 bvJ
 bvJ
-bvK
+vwd
 nua
 bGM
 bMr
 bJN
-bJN
-bJN
-bJN
-bJN
-bhA
-bhA
-mwK
-mwK
-mwK
-mwK
-mwK
+bDb
+bDb
+bDb
+bDb
+bvx
+bvx
+xQR
+xQR
+xQR
+xQR
+xQR
 xQR
 bDb
 srU
@@ -108730,7 +108986,7 @@ mtK
 mtK
 mtK
 cmn
-cmn
+bCL
 cda
 cOT
 xzh
@@ -108978,15 +109234,15 @@ pxV
 pxV
 lSv
 njf
-jsw
-jsw
-jsw
+heh
+heh
+heh
 cmq
-jsw
+heh
 upr
 cri
 cTI
-cmn
+vki
 cBT
 cBU
 cOT
@@ -113085,9 +113341,9 @@ mtK
 mtK
 mtK
 jVl
-pxV
+iKC
 cjF
-cks
+xnv
 clx
 cks
 cnk

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -366,7 +366,7 @@
 /obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "adX" = (
@@ -699,8 +699,8 @@
 	name = "Engine Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "ahY" = (
@@ -2034,7 +2034,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood/tile,
 /area/station/security/detectives_office)
 "atb" = (
 /obj/structure/chair/sofa/corner{
@@ -4271,6 +4271,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aFN" = (
@@ -5124,7 +5125,6 @@
 	},
 /area/station/hallway/primary/central)
 "aJz" = (
-/obj/machinery/light/directional/west,
 /obj/structure/chair/sofa/right{
 	color = "#8a3033";
 	dir = 4
@@ -5626,7 +5626,6 @@
 	},
 /area/station/commons/dorms)
 "aLU" = (
-/obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_large"
@@ -5981,6 +5980,7 @@
 /area/station/hallway/primary/port)
 "aNu" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_large"
 	},
@@ -14929,12 +14929,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
-"bxL" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Central Hallway South-East"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "bxO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -17752,7 +17746,12 @@
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/door/window/right/directional/south{
 	name = "Brig Desk";
-	req_access = list("brig")
+	req_access = list("brig");
+	dir = 1
+	},
+/obj/machinery/door/window/right/directional/east{
+	name = "Brig Reception";
+	dir = 2
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -19035,7 +19034,7 @@
 /area/station/medical/virology)
 "bNf" = (
 /obj/structure/sign/warning/biohazard,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/medical/virology)
 "bNh" = (
 /obj/machinery/computer/pandemic,
@@ -19348,7 +19347,6 @@
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
 "bOl" = (
-/obj/machinery/announcement_system,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
@@ -19467,6 +19465,10 @@
 	location = "Atmospherics"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bOU" = (
@@ -21323,6 +21325,7 @@
 "bYr" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "bYs" = (
@@ -22013,6 +22016,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ccf" = (
@@ -22677,6 +22681,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cfw" = (
@@ -23479,6 +23484,7 @@
 	name = "Bar Entrance"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_half"
 	},
@@ -26414,11 +26420,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"cBg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/station/service/hydroponics)
 "cBh" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue{
@@ -28859,6 +28860,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dmq" = (
@@ -29810,6 +29812,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_cafeteria)
 "dQy" = (
@@ -30524,7 +30527,6 @@
 /area/station/security/eva)
 "elT" = (
 /obj/machinery/shower/directional/west,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
@@ -31829,12 +31831,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
-"fdH" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
-/turf/closed/wall/r_wall,
-/area/station/security/execution)
 "fdR" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/red/line{
@@ -33850,9 +33846,12 @@
 	},
 /area/station/service/chapel)
 "gsv" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/closed/wall,
-/area/station/maintenance/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/window/right/directional/east{
+	name = "Brig Reception"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "gsX" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	icon_state = "tile_half_contrasted";
@@ -36743,10 +36742,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"icK" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/turf/closed/wall/r_wall,
-/area/station/security/execution)
 "icT" = (
 /obj/structure/table/wood/fancy,
 /obj/effect/spawner/random/entertainment/deck,
@@ -39714,6 +39709,12 @@
 	dir = 1
 	},
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/button/door/directional/west{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_y = 10;
+	req_access = list("engineering")
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "jRA" = (
@@ -40436,6 +40437,9 @@
 	},
 /obj/effect/landmark/start/hangover,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Central Hallway South-East"
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "kpg" = (
@@ -40584,7 +40588,6 @@
 /obj/item/reagent_containers/cup/bucket{
 	pixel_x = -4
 	},
-/obj/item/wirecutters,
 /obj/item/shovel/spade,
 /obj/item/shovel/spade,
 /obj/item/cultivator,
@@ -41582,11 +41585,8 @@
 /area/station/hallway/secondary/service)
 "kWJ" = (
 /obj/structure/sign/warning/secure_area/directional/west,
-/obj/machinery/light_switch/directional/west{
-	pixel_x = 0;
-	pixel_y = -39
-	},
 /obj/item/kirbyplants/random,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
 "kWK" = (
@@ -42999,12 +42999,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/ordnance/bomb)
-"lQV" = (
-/obj/machinery/door/window/left/directional/north,
-/turf/open/floor/engine{
-	name = "Holodeck Projector Floor"
-	},
-/area/station/holodeck/rec_center)
 "lRe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_blue,
@@ -45538,7 +45532,6 @@
 /obj/structure/cable,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/flashlight/lamp,
-/obj/item/flashlight/lamp/green,
 /turf/open/floor/iron/dark/smooth_large{
 	icon_state = "textured_dark_large"
 	},
@@ -46530,8 +46523,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
-	id = "experilab";
-	name = "Experimentation Lab Lockdown"
+	id = "cytologysecure";
+	name = "Secure Pen Lockdown"
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
@@ -46648,8 +46641,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ogm" = (
-/turf/closed/wall,
-/area/station/science/ordnance/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "ogn" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 1
@@ -46738,7 +46736,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/locker)
 "ohL" = (
-/obj/structure/sign/poster/official/safety_report/directional/south,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 8
 	},
@@ -51880,6 +51877,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "rtf" = (
@@ -52086,9 +52084,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "rBN" = (
-/obj/effect/turf_decal/bot,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/disposal/incinerator)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics)
 "rBV" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -53669,9 +53667,11 @@
 	},
 /obj/machinery/door/window/left/directional/west{
 	name = "Atmospherics Delivery";
-	req_access = list("atmospherics")
+	req_access = list("atmospherics");
+	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sCj" = (
@@ -58414,12 +58414,6 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"vtd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/command/storage/eva)
 "vtB" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -58451,7 +58445,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "vvd" = (
@@ -59334,6 +59327,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood/large{
 	icon_state = "wood_tile"
 	},
@@ -59552,7 +59546,10 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/door/window/brigdoor/right/directional/north,
+/obj/machinery/door/window/brigdoor/right/directional/north{
+	req_access = list("security");
+	name = "Security Delivery"
+	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -60259,11 +60256,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "wEw" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/station/security/prison/safe)
+/obj/machinery/announcement_system,
+/turf/open/floor/iron,
+/area/station/tcommsat/computer)
 "wEM" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab"
@@ -61159,6 +61154,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/maintenance/abandon_arcade)
 "xcG" = (
@@ -61242,6 +61238,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden/abandoned)
 "xgf" = (
@@ -62608,7 +62605,6 @@
 /obj/structure/sign/warning/no_smoking{
 	pixel_x = -25
 	},
-/obj/structure/noticeboard/directional/south,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 5
 	},
@@ -79852,8 +79848,8 @@ alR
 aom
 aoX
 apP
-amC
-amC
+aol
+aol
 aol
 aol
 aol
@@ -82745,7 +82741,7 @@ sUX
 sUX
 bCq
 bVy
-bLv
+gsv
 cyE
 bLv
 bLv
@@ -82955,7 +82951,7 @@ uRo
 dwC
 aLE
 lAq
-aOl
+ogm
 aPG
 aPG
 aPG
@@ -84719,9 +84715,9 @@ tvg
 qCC
 uNJ
 vjN
-fdH
+pcN
 oyV
-icK
+pcN
 rda
 rda
 rda
@@ -88591,7 +88587,7 @@ aiX
 oyd
 ata
 vEV
-wYB
+oyd
 uOe
 mOD
 pAS
@@ -88848,7 +88844,7 @@ uca
 tcz
 xNa
 kDW
-wYB
+oyd
 pVZ
 mOD
 jYo
@@ -89105,7 +89101,7 @@ kFq
 kFq
 hei
 wdv
-wYB
+oyd
 xLC
 tXb
 ehe
@@ -89360,9 +89356,9 @@ aiX
 aiX
 aiX
 aiX
-wYB
+oyd
 hns
-wYB
+oyd
 gmK
 wYB
 wYB
@@ -90140,8 +90136,8 @@ qVN
 sLL
 jsQ
 ayL
-vtd
-vtd
+ayL
+ayL
 ayL
 hbs
 aMy
@@ -90712,7 +90708,7 @@ cCc
 bCq
 bHE
 tau
-bVJ
+wEw
 bOM
 bQd
 bZv
@@ -94466,7 +94462,7 @@ vwM
 hAC
 vMs
 atb
-wEw
+aaJ
 nuR
 gIk
 lGD
@@ -94742,7 +94738,7 @@ jAD
 uBA
 uBA
 afA
-qEg
+fNL
 cpc
 ukX
 tOQ
@@ -96321,9 +96317,9 @@ aJq
 aJq
 aJq
 aJq
+aJq
+aJq
 aRt
-aJq
-aJq
 wKH
 aJq
 aJq
@@ -96345,10 +96341,10 @@ aXf
 aJq
 koN
 aJq
-bxL
+aJq
+aJq
+aJq
 aRt
-aJq
-aJq
 bCA
 bzs
 caS
@@ -99952,7 +99948,7 @@ lOZ
 vki
 kbG
 rrA
-bRa
+bzs
 hxs
 bzs
 hLb
@@ -100231,7 +100227,7 @@ bzs
 bzs
 bzs
 bRa
-rBN
+cmd
 iYO
 jxd
 bAP
@@ -100724,7 +100720,7 @@ pHl
 bFA
 wXA
 bzs
-gsv
+bzs
 bzs
 bzs
 bzs
@@ -101435,7 +101431,7 @@ aro
 aro
 aro
 aro
-lQV
+aro
 rQR
 oJU
 oJU
@@ -102267,7 +102263,7 @@ eIZ
 xrc
 bpI
 bpI
-bRN
+bNd
 bNd
 bNd
 bNd
@@ -102524,7 +102520,7 @@ owg
 bFM
 btR
 yce
-bRN
+bNd
 uJF
 bIL
 sXw
@@ -103295,7 +103291,7 @@ bDS
 bFN
 pSk
 pSk
-bRN
+bNd
 bNd
 bNd
 bNd
@@ -103779,8 +103775,8 @@ ayi
 ayp
 xJe
 kBB
-aXo
-cBg
+rBN
+bam
 bam
 aYV
 iKz
@@ -110235,7 +110231,7 @@ bxP
 bIB
 dKC
 yaT
-ogm
+cas
 hte
 lrt
 bQU
@@ -110492,7 +110488,7 @@ cpN
 bCg
 tiR
 ohL
-ogm
+cas
 bNt
 jxt
 bQT
@@ -110749,7 +110745,7 @@ kdP
 jzb
 rMn
 oNw
-ogm
+cas
 bOE
 dZn
 xkx
@@ -111006,7 +111002,7 @@ aLu
 bCg
 aXE
 euc
-ogm
+cas
 aXJ
 aYx
 nEP
@@ -111263,14 +111259,14 @@ byb
 uEh
 rMU
 rAg
-ogm
-ogm
-ogm
-ogm
+cas
+cas
+cas
+cas
 rfL
-ogm
-ogm
-ogm
+cas
+cas
+cas
 cas
 hJz
 wBE

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -361,6 +361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "adX" = (
@@ -695,6 +696,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "ahY" = (
@@ -19617,6 +19619,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "bQL" = (
@@ -20729,6 +20732,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/landmark/navigate_destination/tcomms,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "bWv" = (
@@ -28413,6 +28417,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/security/prison/work)
 "dda" = (
@@ -28751,6 +28756,7 @@
 	name = "Engineering Foyer"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "doz" = (
@@ -30972,6 +30978,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
 "eHN" = (
@@ -40369,6 +40376,7 @@
 	name = "Engineering Foyer"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/break_room)
 "kpu" = (
@@ -47839,6 +47847,16 @@
 	dir = 5
 	},
 /area/station/service/chapel)
+"oVX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_large,
+/area/station/engineering/main)
 "oWg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48616,6 +48634,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"puC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
+/area/station/engineering/main)
 "puJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -93689,7 +93717,7 @@ cfb
 cfb
 cfb
 clR
-aiN
+oVX
 cgR
 cMm
 cMm
@@ -93946,7 +93974,7 @@ aeS
 ahx
 cjk
 cmF
-aiN
+puC
 bkM
 cqP
 cMm

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -392,6 +392,9 @@
 	dir = 8
 	},
 /obj/machinery/photocopier/prebuilt,
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "aeb" = (
@@ -468,12 +471,14 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_x = -28
-	},
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "qmroom";
+	name = "Privacy Blast Doors Control";
+	pixel_y = -7
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
@@ -582,6 +587,9 @@
 /area/station/command/heads_quarters/qm)
 "afw" = (
 /obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmroom"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "afA" = (
@@ -718,6 +726,7 @@
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 1
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aih" = (
@@ -4016,6 +4025,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "aDK" = (
@@ -4028,6 +4038,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/common/cryopods)
 "aDO" = (
@@ -9070,7 +9081,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "bbb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -9892,6 +9903,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/cargo/bitrunning/den)
 "bez" = (
@@ -11884,6 +11896,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "bmV" = (
@@ -11940,6 +11953,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "bnb" = (
@@ -12003,6 +12017,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "bnv" = (
@@ -12300,6 +12315,7 @@
 "boi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "boj" = (
@@ -12370,6 +12386,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "boD" = (
@@ -14344,9 +14361,9 @@
 /area/station/science/research)
 "bvJ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "rdprivacy"
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
@@ -16054,9 +16071,6 @@
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
 "bDc" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Research Director"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -16066,6 +16080,9 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Office"
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
 "bDd" = (
@@ -17117,6 +17134,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "bGN" = (
@@ -21476,6 +21494,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/science/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/science/cytology)
 "caq" = (
@@ -23438,13 +23457,14 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "ckO" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Engineer"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office"
+	},
 /turf/open/floor/iron/smooth_large,
 /area/station/command/heads_quarters/ce)
 "ckS" = (
@@ -24482,7 +24502,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "csO" = (
 /obj/structure/window/reinforced/fulltile,
@@ -24526,13 +24546,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/transit_tube/station/dispenser/reverse,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "csV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "csX" = (
 /obj/structure/sign/warning/vacuum/external/directional/north,
@@ -24560,7 +24580,10 @@
 /turf/open/floor/plating/airless,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctb" = (
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -24569,8 +24592,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/cable/layer3,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctg" = (
 /obj/structure/closet/emcloset{
@@ -24580,12 +24603,10 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cth" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/light/small/broken/directional/south,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "cti" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/secure_area/directional/south,
@@ -24597,11 +24618,8 @@
 	network = list("minisat");
 	start_active = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/light/small/broken/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cto" = (
 /obj/machinery/door/airlock/hatch{
@@ -24612,7 +24630,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
-/obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctq" = (
@@ -24624,7 +24642,7 @@
 "ctt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctu" = (
@@ -24641,7 +24659,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctz" = (
@@ -24701,6 +24719,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctK" = (
@@ -24748,6 +24767,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ctX" = (
@@ -24798,6 +24818,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cuf" = (
@@ -24830,6 +24851,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cum" = (
@@ -24901,6 +24923,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cuv" = (
@@ -25010,6 +25033,7 @@
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cuH" = (
@@ -25110,6 +25134,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/simple_animal/bot/secbot/pingsky,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cuT" = (
@@ -25202,6 +25227,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cvf" = (
@@ -25248,6 +25274,7 @@
 	cycle_id = "ai-passthrough"
 	},
 /obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cvp" = (
@@ -25313,6 +25340,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cvA" = (
@@ -25345,7 +25373,7 @@
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "cvC" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "cvD" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -25376,6 +25404,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cvJ" = (
@@ -25389,7 +25418,7 @@
 "cvL" = (
 /obj/structure/sign/warning/secure_area/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "cvM" = (
 /obj/machinery/camera/motion/directional/west{
@@ -25402,8 +25431,7 @@
 "cvN" = (
 /obj/structure/sign/warning/secure_area/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "cvP" = (
 /turf/closed/wall,
@@ -25413,6 +25441,7 @@
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cvU" = (
@@ -25468,6 +25497,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cwe" = (
@@ -25483,6 +25513,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwg" = (
@@ -25509,6 +25540,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwk" = (
@@ -25541,6 +25573,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwp" = (
@@ -25567,6 +25600,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwu" = (
@@ -25576,6 +25610,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwv" = (
@@ -25590,6 +25625,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwx" = (
@@ -25597,6 +25633,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwz" = (
@@ -25614,6 +25651,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cwB" = (
@@ -26224,6 +26262,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cAW" = (
@@ -26243,6 +26282,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "cAZ" = (
 /obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cBa" = (
@@ -26261,11 +26301,13 @@
 /area/station/ai_monitored/turret_protected/ai)
 "cBd" = (
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cBe" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "cBh" = (
@@ -26427,6 +26469,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cBT" = (
@@ -28548,6 +28591,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"dgI" = (
+/obj/structure/cable/multilayer/connected,
+/turf/open/space/basic,
+/area/space)
 "dgP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -29739,8 +29786,7 @@
 "dSm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "dSx" = (
 /obj/effect/turf_decal/plaque{
@@ -30571,7 +30617,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "esZ" = (
@@ -33911,7 +33956,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "gBO" = (
 /obj/machinery/navbeacon{
@@ -34125,14 +34170,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "gGQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gGW" = (
 /obj/effect/turf_decal/trimline/blue/line{
@@ -34261,6 +34306,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "gJP" = (
@@ -35430,6 +35476,7 @@
 	name = "Gravity Generator Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/gravity_generator)
 "hte" = (
@@ -35739,7 +35786,8 @@
 /obj/machinery/button/door/directional/south{
 	pixel_y = -38;
 	pixel_x = 6;
-	id = "rdprivacy"
+	id = "rdoffice";
+	name = "privacy shutters control"
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/command/heads_quarters/rd)
@@ -36038,7 +36086,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "hKq" = (
 /obj/structure/disposalpipe/segment,
@@ -36214,6 +36262,7 @@
 	pixel_y = 16
 	},
 /obj/item/toy/crayon/spraycan/roboticist,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/checker,
 /area/station/science/robotics/lab)
 "hOM" = (
@@ -38612,7 +38661,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "jop" = (
 /obj/structure/table/glass,
@@ -38745,6 +38794,7 @@
 	req_access = list("virology");
 	pixel_x = -24
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "jsw" = (
@@ -39041,15 +39091,12 @@
 	},
 /area/station/science/research)
 "jzP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jAi" = (
 /obj/effect/turf_decal/siding/white,
@@ -40031,27 +40078,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "kdV" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/clothing/suit/caution,
-/obj/item/clothing/suit/caution,
-/obj/item/clothing/suit/caution,
-/obj/item/clothing/suit/caution,
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/mop,
-/obj/item/mop,
-/obj/item/clothing/gloves/color/blue,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/item/storage/bag/trash,
-/obj/item/pushbroom,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/kitchen{
-	dir = 1
-	},
-/area/station/security/prison/work)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/ai_monitored/turret_protected/aisat/maint)
 "ken" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40927,6 +40959,7 @@
 	id_tag = "HoSdoor";
 	name = "Head Of Security's Office"
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "kFL" = (
@@ -41793,6 +41826,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark{
 	icon_state = "textured_dark_large"
 	},
@@ -42213,6 +42247,9 @@
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/mop_bucket/janitorialcart{
+	dir = 4
 	},
 /turf/open/floor/iron/kitchen{
 	dir = 1
@@ -42948,14 +42985,11 @@
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/hallway/primary/central)
 "lSX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/prison)
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "lSY" = (
 /obj/machinery/computer/bank_machine,
 /obj/effect/turf_decal/bot_white,
@@ -43653,14 +43687,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "mrS" = (
-/obj/structure/mop_bucket/janitorialcart{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/toy/crayon/spraycan,
+/obj/item/reagent_containers/hypospray/medipen,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -44395,6 +44430,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "mUV" = (
@@ -47170,6 +47209,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "ozj" = (
@@ -49080,6 +49120,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"pIV" = (
+/turf/open/floor/catwalk_floor,
+/area/station/ai_monitored/turret_protected/aisat_interior)
 "pIW" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
@@ -50874,13 +50917,23 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qTa" = (
-/obj/structure/closet/crate/trashcart/laundry,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/obj/item/reagent_containers/hypospray/medipen,
-/obj/item/toy/crayon/spraycan,
-/obj/effect/spawner/random/contraband/prison,
+/obj/item/storage/bag/trash,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/gloves/color/blue,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/clothing/suit/caution,
+/obj/item/pushbroom,
+/obj/item/clothing/suit/caution,
+/obj/item/mop,
+/obj/item/clothing/suit/caution,
+/obj/item/mop,
+/obj/item/clothing/suit/caution,
+/obj/structure/rack,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/kitchen{
 	dir = 1
 	},
@@ -53352,7 +53405,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "sxQ" = (
 /obj/effect/turf_decal/stripes/line,
@@ -55216,6 +55269,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "txJ" = (
@@ -56661,7 +56715,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "uxl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58720,10 +58774,10 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/door/airlock/command/glass{
-	name = "Quartermaster"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/machinery/door/airlock/mining{
+	name = "Quartermaster's Office"
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "vFb" = (
@@ -59307,6 +59361,10 @@
 /obj/machinery/button/delam_scram,
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
+"vYh" = (
+/obj/structure/cable/layer3,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "vYr" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=EVA2";
@@ -62054,7 +62112,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "xOZ" = (
 /obj/structure/disposalpipe/segment{
@@ -62648,6 +62707,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/medical/psychology,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "yeK" = (
@@ -93594,7 +93654,7 @@ dhx
 wRw
 nxl
 slB
-kdV
+wRw
 wRw
 qXA
 pCQ
@@ -94617,7 +94677,7 @@ obp
 hBI
 aaJ
 tpH
-lSX
+gIk
 hki
 wTh
 vRr
@@ -94874,7 +94934,7 @@ uwH
 bPe
 grX
 nuR
-lSX
+gIk
 ePP
 wTh
 woc
@@ -95131,7 +95191,7 @@ xFC
 nKA
 grX
 nuR
-lSX
+gIk
 ePP
 wTh
 sbJ
@@ -95388,7 +95448,7 @@ ryT
 hiN
 aaJ
 nmZ
-lSX
+gIk
 ePP
 wTh
 lkK
@@ -95645,7 +95705,7 @@ klk
 hjJ
 aaJ
 sRy
-lSX
+gIk
 ePP
 wTh
 vuB
@@ -99636,7 +99696,7 @@ xzh
 xzh
 xzh
 xzh
-xzh
+dgI
 xzh
 ctZ
 ctZ
@@ -99915,14 +99975,14 @@ pjU
 pjU
 pjU
 pjU
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
+pjU
+pjU
+pjU
+pjU
+pjU
+pjU
+pjU
+pjU
 xzh
 xzh
 xzh
@@ -100179,8 +100239,8 @@ cva
 cva
 cva
 cva
-cva
-cva
+pjU
+pjU
 xzh
 xzh
 xzh
@@ -100437,8 +100497,8 @@ cva
 cva
 cva
 cva
-cva
-cva
+pjU
+pjU
 sUX
 oFI
 xzh
@@ -100695,7 +100755,7 @@ cwv
 cvp
 cva
 cva
-cva
+pjU
 xzh
 bBM
 xzh
@@ -100948,11 +101008,11 @@ boi
 boC
 cAV
 cAZ
-cvl
-cvl
+vYh
+vYh
 cva
 cva
-cva
+pjU
 xzh
 bBM
 xzh
@@ -101173,7 +101233,7 @@ csD
 csN
 csV
 ctb
-cth
+cub
 cua
 jpF
 ctu
@@ -101209,7 +101269,7 @@ cBb
 cBd
 cva
 cva
-cva
+pjU
 xzh
 bBM
 xzh
@@ -101466,7 +101526,7 @@ bNX
 cBe
 cva
 cva
-cva
+pjU
 bJw
 bBM
 xzh
@@ -101684,9 +101744,9 @@ xzh
 sUX
 xzh
 csD
-ctb
+pIV
 csV
-ctb
+lSX
 ctj
 ctq
 cYD
@@ -101723,7 +101783,7 @@ cvp
 cvl
 cva
 cva
-cva
+pjU
 xzh
 bBM
 xzh
@@ -101980,7 +102040,7 @@ cvl
 cvl
 cva
 cva
-cva
+pjU
 xzh
 bBM
 xzh
@@ -102237,7 +102297,7 @@ cwB
 cvp
 cva
 cva
-cva
+pjU
 xzh
 bBM
 xzh
@@ -102477,8 +102537,8 @@ dSm
 cvN
 gBt
 xOA
-gVV
-cvX
+kdV
+cth
 cvX
 cva
 cva
@@ -102493,8 +102553,8 @@ cva
 cva
 cva
 cva
-cva
-cva
+pjU
+pjU
 sUX
 oFI
 xzh
@@ -102749,8 +102809,8 @@ cva
 cva
 cva
 cva
-cva
-cva
+pjU
+pjU
 xzh
 xzh
 xzh
@@ -102999,14 +103059,14 @@ pjU
 pjU
 pjU
 pjU
-cva
-cva
-cva
-cva
-cva
-cva
-cva
-cva
+pjU
+pjU
+pjU
+pjU
+pjU
+pjU
+pjU
+pjU
 xzh
 xzh
 xzh

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -11299,6 +11299,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "bkN" = (
@@ -23713,6 +23714,7 @@
 /area/station/engineering/main)
 "cny" = (
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_large,
 /area/station/engineering/main)
 "cnA" = (
@@ -47847,16 +47849,6 @@
 	dir = 5
 	},
 /area/station/service/chapel)
-"oVX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
 "oWg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48634,16 +48626,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
-"puC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
-/area/station/engineering/main)
 "puJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -93717,8 +93699,8 @@ cfb
 cfb
 cfb
 clR
-oVX
-cgR
+kja
+ckH
 cMm
 cMm
 cDt
@@ -93974,7 +93956,7 @@ aeS
 ahx
 cjk
 cmF
-puC
+kja
 bkM
 cqP
 cMm


### PR DESCRIPTION

## О Pull Request
Фиксит ИИсат, пару офисов глав. Накидывает меток для навигации на важные локи, чтобы игрокам было искать проще.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Теперь можно поговорить тет-а-тет

## Доказательства тестирования
На локалке я прожал кнопку "зарядить все АПЦ" - там поэтому 1.7 мегаватт в сети на скрине со спутника. На деле всё норм.
<details>
<summary>Скриншоты/Видео</summary>
<img width="305" height="413" alt="image" src="https://github.com/user-attachments/assets/0e5daa39-811d-4cdd-8ee9-7493f017b600" />
<img width="622" height="501" alt="image" src="https://github.com/user-attachments/assets/7b7db58b-c6a9-4630-b21b-84de0be74c35" />
<img width="394" height="625" alt="image" src="https://github.com/user-attachments/assets/0349136f-a011-4130-9f19-6c28e077a02e" />
<img width="574" height="382" alt="image" src="https://github.com/user-attachments/assets/131c4648-60de-4e69-9125-79c7da17a03f" />
<img width="308" height="558" alt="image" src="https://github.com/user-attachments/assets/fbbe9b97-ea60-4401-ab1d-8096e21bd904" />
<img width="347" height="280" alt="image" src="https://github.com/user-attachments/assets/ef76a37b-d4d4-4cc7-8d1e-d890ed04c00d" />
<img width="442" height="483" alt="image" src="https://github.com/user-attachments/assets/8cddaafa-870d-48e9-b1c5-9d64899ba4fc" />
<img width="190" height="49" alt="image" src="https://github.com/user-attachments/assets/565e5411-f581-4397-8591-651356566b0d" />
<img width="485" height="497" alt="image" src="https://github.com/user-attachments/assets/67eb351b-192b-4cd4-9e74-8c8d4032a1a4" />
<img width="686" height="476" alt="image" src="https://github.com/user-attachments/assets/6bc0a8b6-51ff-45bf-b34b-f203513bb298" />

</details>

## Changelog
:cl:
map: Fixes the NSS Journey AI minisat powernet
map: Makes head of staff offices on NSS Journey actually private with shutters closed
map: Adds some more navigation destinations to NSS Journey
/:cl:
