### PR TITLE
DeZaibas - послабление пулемета и снайперской пульсовки.

### DIFF
--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
@@ -43,8 +43,8 @@
 	. = ..()
 	AddElement(/datum/element/item_scaling, 0.45, 1)
 	remaining_uses = max_uses
-	if(projectile_type)
-		loaded_projectile = new projectile_type(src)
+	//if(projectile_type)
+	//	loaded_projectile = new projectile_type(src)
 
 /obj/item/ammo_casing/pulse/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/fired_from)
 	if(remaining_uses <= 0)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
@@ -43,8 +43,8 @@
 	. = ..()
 	AddElement(/datum/element/item_scaling, 0.45, 1)
 	remaining_uses = max_uses
-	//if(projectile_type) // FLUFFY EDIT: BUGFIX?. ВНИМАНИЕ: БАГ, Возможно где-то здесь добавляются лишние 15 снарядов при спавне оружия. Так же снаряды могут врезаться в стрелка, если тот бежит вслед за ними.
-	//	loaded_projectile = new projectile_type(src)
+	if(projectile_type)
+		loaded_projectile = new projectile_type(src)
 
 /obj/item/ammo_casing/pulse/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/fired_from)
 	if(remaining_uses <= 0)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/ammo/pulse.dm
@@ -43,7 +43,7 @@
 	. = ..()
 	AddElement(/datum/element/item_scaling, 0.45, 1)
 	remaining_uses = max_uses
-	//if(projectile_type)
+	//if(projectile_type) // FLUFFY EDIT: BUGFIX?. ВНИМАНИЕ: БАГ, Возможно где-то здесь добавляются лишние 15 снарядов при спавне оружия. Так же снаряды могут врезаться в стрелка, если тот бежит вслед за ними.
 	//	loaded_projectile = new projectile_type(src)
 
 /obj/item/ammo_casing/pulse/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/fired_from)

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -150,7 +150,7 @@
 	icon_state = "zaibas_mag"
 	ammo_type = /obj/item/ammo_casing/pulse
 	caliber = "pulse"
-	max_ammo = 3
+	max_ammo = 1 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1.
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 	///Purely flavor short designation that appears in the magazines' notes.
 	var/magazine_designation = "'SD-3C'"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -150,7 +150,7 @@
 	icon_state = "zaibas_mag"
 	ammo_type = /obj/item/ammo_casing/pulse
 	caliber = "pulse"
-	max_ammo = 1 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1.
+	max_ammo = 2 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1.
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 	///Purely flavor short designation that appears in the magazines' notes.
 	var/magazine_designation = "'SD-3C'"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/magazines.dm
@@ -150,7 +150,7 @@
 	icon_state = "zaibas_mag"
 	ammo_type = /obj/item/ammo_casing/pulse
 	caliber = "pulse"
-	max_ammo = 2 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1.
+	max_ammo = 2 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 3.
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 	///Purely flavor short designation that appears in the magazines' notes.
 	var/magazine_designation = "'SD-3C'"

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_rifle.dm
@@ -25,7 +25,8 @@
 	burst_size = 3
 	fire_delay = 2
 
-	spread = 1
+	projectile_damage_multiplier = 0.8 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1
+	spread = 3 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1
 	recoil = 0.5
 
 	w_class = WEIGHT_CLASS_BULKY

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_rifle.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_rifle.dm
@@ -25,7 +25,7 @@
 	burst_size = 3
 	fire_delay = 2
 
-	projectile_damage_multiplier = 0.8 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1
+	projectile_damage_multiplier = 0.8 //FLUFFY FRONTIER ADDITION. ZAIBAS NERF. ORIGINAL: 1
 	spread = 3 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1
 	recoil = 0.5
 

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_sniper.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_sniper.dm
@@ -23,7 +23,7 @@
 	rack_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_pull.ogg'
 	bolt_drop_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_push.ogg'
 
-	spread = 3 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1
+	spread = 3 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 2.5
 	recoil = 1
 	projectile_damage_multiplier = 1.5 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 2
 	projectile_speed_multiplier = 2 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 2.5

--- a/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_sniper.dm
+++ b/modular_nova/modules/modular_weapons/code/company_and_or_faction_based/szot_dynamica/pulse_sniper.dm
@@ -23,10 +23,10 @@
 	rack_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_pull.ogg'
 	bolt_drop_sound = 'modular_nova/modules/modular_weapons/sounds/pulse_push.ogg'
 
-	spread = 2.5
+	spread = 3 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 1
 	recoil = 1
-	projectile_damage_multiplier = 2
-	projectile_speed_multiplier = 2.5
+	projectile_damage_multiplier = 1.5 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 2
+	projectile_speed_multiplier = 2 //FLUFFY FRONTIER EDIT. ZAIBAS NERF. ORIGINAL: 2.5
 
 	weapon_weight = WEAPON_HEAVY
 	internal_magazine = TRUE


### PR DESCRIPTION

## О Pull Request

ПР сделан по предложке
БЫЛО -> СТАЛО

pulse_rifle
Damage multiplier: 1 → 0.8
Spread: 1 → 3
Magazine: 60 → 30

pulse_sniper
Damage multiplier: 2 → 1.5
Projectile speed: 2.5 → 2
Spread: 2.5 → 3

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Убирает оружие из SSR тира и дополнительно ВОЗМОЖНО фиксит баг с лишними 15 патронами при спавне пушки.

Оружие сильно багует, к сожалению.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

https://github.com/user-attachments/assets/41dc9926-4753-4d5a-9d59-3cce1a7039b8


</details>

## Changelog

:cl:
balance: Spread, damage, speed and nerfs to Zaibas weaponry.
/:cl:
