### PR TITLE
наплак демона резни

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/demon/demon_subtypes.dm
+++ b/code/modules/mob/living/basic/space_fauna/demon/demon_subtypes.dm
@@ -14,8 +14,8 @@
 	// their wound bonuses grow and grow higher. this is how they're able to efficiently kill and slaughter their victims.
 	// consider this before you balance them.
 	obj_damage = 50
-	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_lower = 20 // FLUFFY FRONTIER CHANGES - ORIGINAL: 15
+	melee_damage_upper = 20 // FLUFFY FRONTIER CHANGES - ORIGINAL: 15
 	wound_bonus = -10
 	exposed_wound_bonus = 0
 	sharpness = SHARP_EDGED

--- a/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
@@ -178,7 +178,11 @@
 	if(!.)
 		return
 
+	// FLUFFY FRONTIER REMOVAL - NO MORE JAUNT DAMAGE
+	/*
 	jaunt_damage_timer = addtimer(CALLBACK(src, PROC_REF(damage_for_lazy_demon), jaunter), 20 SECONDS, TIMER_STOPPABLE)
+	*/
+	// FLUFFY FRONTIER REMOVAL END
 
 	var/turf/jaunt_turf = get_turf(jaunter)
 	// if we're not pulling anyone, or we can't what we're pulling
@@ -219,6 +223,8 @@
  * Apply damage to demon when he using bloodcrawl.
  * Every 20 SECONDS check if demon still crawling and update timer.
  */
+// FLUFFY FRONTIER REMOVAL
+/*
 /datum/action/cooldown/spell/jaunt/bloodcrawl/slaughter_demon/proc/damage_for_lazy_demon(mob/living/lazy_demon)
 	if(QDELETED(lazy_demon))
 		return
@@ -231,6 +237,9 @@
 	lazy_demon.apply_damage(lazy_demon.maxHealth * 0.05, BRUTE)
 	jaunt_damage_timer = addtimer(CALLBACK(src, PROC_REF(damage_for_lazy_demon), lazy_demon), 20 SECONDS, TIMER_STOPPABLE)
 	to_chat(lazy_demon, span_warning("You feel your flesh dissolving into the sea of blood. You shouldn't stay in Blood Crawl for too long!"))
+
+// FLUFFY FRONTIER REMOVAL END
+*/
 
 /**
  * Consumes the [victim] from the [jaunter], fully healing them
@@ -267,18 +276,26 @@
  * Called when a victim starts to be consumed.
  */
 /datum/action/cooldown/spell/jaunt/bloodcrawl/slaughter_demon/proc/on_victim_start_consume(mob/living/victim, mob/living/jaunter)
+	// FLUFFY FRONTIER REMOVAL
+	/*
 	if(!iscarbon(jaunter))
 		resist_jaunt_damage = TRUE
 		deltimer(jaunt_damage_timer)
+	*/
+	// FLUFFY FRONTIER REMOVAL END
 	to_chat(jaunter, span_danger("You begin to feast on [victim]... You can not move while you are doing this."))
 
 /**
  * Called when a victim is successfully consumed.
  */
 /datum/action/cooldown/spell/jaunt/bloodcrawl/slaughter_demon/proc/on_victim_consumed(mob/living/victim, mob/living/jaunter)
+	// FLUFFY FRONTIER REMOVAL
+	/*
 	if(!iscarbon(jaunter))
 		resist_jaunt_damage = FALSE
 		jaunt_damage_timer = addtimer(CALLBACK(src, PROC_REF(damage_for_lazy_demon), jaunter), 20 SECONDS, TIMER_STOPPABLE)
+	*/
+	// FLUFFY FRONTIER REMOVAL END
 	to_chat(jaunter, span_danger("You devour [victim]. Your health is fully restored."))
 	qdel(victim)
 


### PR DESCRIPTION

## О Pull Request

Демон резни больше  не умирает от того, что находится в джаунте.

Урон увеличен с 15 до 20.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Фишка с "получением урона в джаунте" была добавлена чтобы демон резни играл активно, и в условиях ТГ это звучит адекватно - повсюду кровь, хаос и вряд ли кто-то будет заниматься уборкой крови когда тебе маг сырный круг на мостике рисует.

Но что мы видим на ФФ? На фф при обнаружении демона все силы идут на чистку пола, из-за чего демон умирает тупо от того, что не нашел кровь)). Если нет других антагов, демон резни становится бесполезным. А 15 урона это тупо смешно, даже у пауков больше урона.

## Доказательства тестирования

<details>
<summary>Скриншоты/Видео</summary>

<img width="401" height="282" alt="image" src="https://github.com/user-attachments/assets/8b9d93c0-9519-4a89-acc0-a276f7f01186" />

</details>

## Changelog
:cl:
del: Убран урон от нахождения в джаунте у демона резни.
balance: Урон демона резни увеличен на 5 единиц.
/:cl:
