### PR TITLE
Исправление новогодних рецептов

### DIFF
--- a/tff_modular/modules/new_year_pack/code/food_recipes.dm
+++ b/tff_modular/modules/new_year_pack/code/food_recipes.dm
@@ -11,7 +11,7 @@
 		/datum/reagent/consumable/mayonnaise = 5,
 	)
 	result = /obj/item/food/salad/olivier
-	category = DISH_SALAD
+	dish_category = DISH_SALAD
 	time = 10 SECONDS
 
 /datum/crafting_recipe/food/vinegret_salad
@@ -26,7 +26,7 @@
 		/datum/reagent/consumable/vinegar = 1,
 	)
 	result = /obj/item/food/salad/vinegret
-	category = DISH_SALAD
+	dish_category = DISH_SALAD
 	time = 10 SECONDS
 
 /datum/crafting_recipe/food/kraboviy_salad
@@ -39,7 +39,7 @@
 		/datum/reagent/consumable/mayonnaise = 5,
 	)
 	result = /obj/item/food/salad/kraboviy
-	category = DISH_SALAD
+	dish_category = DISH_SALAD
 	time = 10 SECONDS
 
 /datum/crafting_recipe/food/shuba
@@ -55,7 +55,7 @@
 		/datum/reagent/consumable/mayonnaise = 10,
 	)
 	result = /obj/item/food/cake/shuba
-	category = DISH_SALAD
+	dish_category = DISH_SALAD
 	time = 10 SECONDS
 
 /datum/crafting_recipe/food/kholodetz
@@ -68,7 +68,7 @@
 		/obj/item/food/grown/herbs = 1,
 	)
 	result = /obj/item/food/cake/kholodetz
-	category = DISH_UNCATEGORIZED
+	dish_category = DISH_SALAD
 	time = 10 SECONDS
 
 
@@ -83,7 +83,7 @@
 		/datum/reagent/consumable/blackpepper = 1,
 	)
 	result = /obj/item/food/christmas_ham/raw
-	category = DISH_UNCATEGORIZED
+	dish_category = DISH_MEAT
 	time = 5 SECONDS
 
 
@@ -96,7 +96,7 @@
 		/obj/item/food/red_caviar = 1,
 	)
 	result = /obj/item/food/sandwich/caviar_butterbrod
-	category = DISH_UNCATEGORIZED
+	dish_category = DISH_SANDWICH
 	added_foodtypes = SEAFOOD
 	time = 5 SECONDS
 
@@ -109,7 +109,7 @@
 		/obj/item/food/moonfish_caviar = 1,
 	)
 	result = /obj/item/food/sandwich/caviar_butterbrod
-	category = DISH_UNCATEGORIZED
+	dish_category = DISH_SANDWICH
 	added_foodtypes = SEAFOOD
 	time = 5 SECONDS
 
@@ -121,7 +121,7 @@
 		/datum/reagent/consumable/nutriment/fat/oil/corn = 5,
 	)
 	result = /obj/item/food/sweets/candy_cane
-	category = DISH_UNCATEGORIZED
+	dish_category = DISH_CANDY
 	time = 5 SECONDS
 
 /datum/crafting_recipe/food/candy_cane_mint
@@ -132,5 +132,5 @@
 		/datum/reagent/consumable/nutriment/fat/oil/corn = 5,
 	)
 	result = /obj/item/food/sweets/candy_cane
-	category = DISH_UNCATEGORIZED
+	dish_category = DISH_CANDY
 	time = 5 SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9876,7 +9876,7 @@
 #include "tff_modular\modules\nanotrasen_consultant\console_ntr.dm"
 #include "tff_modular\modules\new_year_pack\code\food_drinks.dm"
 #include "tff_modular\modules\new_year_pack\code\food_general.dm"
-#include "tff_modular\modules\new_year_pack\code\food_repecies.dm"
+#include "tff_modular\modules\new_year_pack\code\food_recipes.dm"
 #include "tff_modular\modules\new_year_pack\code\~cargo.dm"
 #include "tff_modular\modules\OldWaterbreathQuirk\oldwaterbreathquirk.dm"
 #include "tff_modular\modules\opposing_force\code.dm"


### PR DESCRIPTION
## О Pull Request
Крафты новогодней еды теперь отображаются в вкладке готовки а не крафта

## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Исключительно позитивно

## Доказательства тестирования

## Changelog

:cl:
fix: Рецепты новогодней еды отображаются в вкладке готовки а не крафтинга
/:cl: