### PR TITLE
Cheaper cook express

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -11,7 +11,7 @@
 	announcement_line = "The kitchen has ordered groceries which will arrive on the cargo shuttle! Please make sure it gets to them as soon as possible!"
 	// Discount for items in the chefs category like mining/bitrunning consoles
 	cargo_cost_multiplier =  0.65
-	express_cost_multiplier = 1.1 // FF addition, 2 -> 1.1
+	express_cost_multiplier = 1.1 // FLUFFY FRONTIER ADDITION - #5831
 
 /obj/machinery/computer/order_console/cook/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")

--- a/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -11,7 +11,7 @@
 	announcement_line = "The kitchen has ordered groceries which will arrive on the cargo shuttle! Please make sure it gets to them as soon as possible!"
 	// Discount for items in the chefs category like mining/bitrunning consoles
 	cargo_cost_multiplier =  0.65
-	express_cost_multiplier = 1.1 // FF addition (Just delete it to remove addition)
+	express_cost_multiplier = 1.1 // FF addition, 2 -> 1.1
 
 /obj/machinery/computer/order_console/cook/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")

--- a/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -11,6 +11,7 @@
 	announcement_line = "The kitchen has ordered groceries which will arrive on the cargo shuttle! Please make sure it gets to them as soon as possible!"
 	// Discount for items in the chefs category like mining/bitrunning consoles
 	cargo_cost_multiplier =  0.65
+	express_cost_multiplier = 1.1 // FF addition (Just delete it to remove addition)
 
 /obj/machinery/computer/order_console/cook/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")


### PR DESCRIPTION

## О Pull Request
Добавляет одну единственную строку в код Produce Orders Console, что делает экспресс доставку дешевле чем была, но всё ещё дороже чем если бы была использована стандартная доставка.
## Как это может улучшить/повлиять на игровой процесс/ролевую игру
Поварам придётся меньше тратиться на ингредиенты, им не придётся дрочить баунти кубы всю смену.
## Доказательства тестирования
<details>
<summary>Скриншоты/Видео</summary>
<img width="488" height="23" alt="image" src="https://github.com/user-attachments/assets/bf8c6dcc-79ea-40d8-a8aa-7df2f59fb191" />
<img width="247" height="31" alt="image" src="https://github.com/user-attachments/assets/5c009b6c-3c8a-4db8-af9e-2314b01c5c72" />
</details>

## Changelog
:cl:
qol: Makes Produce Orders Console express option cheaper. (1.1 multiplier instead of 2)
/:cl:
