### PR TITLE
Borgo handcuffs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -852,7 +852,7 @@
 	name = "Security"
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
-		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/borg/apparatus/handcuff, // FLUFFY FRONTIER REPLACE /obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/melee/baton/security/loaded,
 		/obj/item/gun/energy/disabler/cyborg,
 		/obj/item/clothing/mask/gas/sechailer/cyborg,
@@ -1004,7 +1004,7 @@
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/construction/rcd/borg/syndicate,
 		/obj/item/pipe_dispenser,
-		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/borg/apparatus/handcuff, // FLUFFY FRONTIER REPLACE /obj/item/restraints/handcuffs/cable/zipties,
 		/obj/item/extinguisher,
 		/obj/item/weldingtool/largetank/cyborg,
 		/obj/item/analyzer,

--- a/tff_modular/modules/borgo_modules/code/borgo_modules.dm
+++ b/tff_modular/modules/borgo_modules/code/borgo_modules.dm
@@ -1,0 +1,55 @@
+// Handcuffs for borg
+/obj/item/borg/apparatus/handcuff
+	name = "handcuff storage apparatus"
+	desc = "A special apparatus for carrying handcuffs and zipties"
+	icon = 'icons/mob/silicon/robot_items.dmi'
+	icon_state = "borg_beaker_apparatus"
+	storable = list(
+		/obj/item/restraints/handcuffs,
+	)
+	var/image/stored_underlay
+
+/obj/item/borg/apparatus/handcuff/Initialize(mapload)
+	add_glass()
+	RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
+	update_appearance()
+	return ..()
+
+/obj/item/borg/apparatus/handcuff/Destroy()
+	QDEL_NULL(stored)
+	return ..()
+
+/obj/item/borg/apparatus/handcuff/update_overlays()
+	. = ..()
+	if(stored_underlay)
+		underlays -= stored_underlay
+	if(!stored)
+		return
+	stored_underlay = image(stored)
+	stored_underlay.layer = FLOAT_LAYER
+	stored_underlay.plane = FLOAT_PLANE
+	stored_underlay.pixel_w = 0
+	stored_underlay.pixel_x = 0
+	stored_underlay.pixel_y = 0
+	stored_underlay.pixel_z = 0
+	underlays += stored_underlay
+
+/obj/item/borg/apparatus/handcuff/examine()
+	. = ..()
+	. += "The handcuff storage contains:"
+	if(stored)
+		var/obj/item/restraints/handcuffs = stored
+		. += handcuffs.name
+	else
+		. += "Nothing."
+	. += span_notice(" <i>Alt-click</i> will drop the stored handcuffs. ")
+
+/obj/item/borg/apparatus/handcuff/click_alt(mob/living/silicon/robot/user)
+	if(!stored)
+		to_chat(user, span_notice("[src] is empty."))
+		return CLICK_ACTION_BLOCKING
+
+	var/obj/item/restraints/handcuffs = stored
+	user.visible_message(span_notice("[user] dumps [handcuffs] from [src]."), span_notice("You dump [handcuffs] from [src]."))
+	handcuffs.forceMove(drop_location())
+	return CLICK_ACTION_SUCCESS

--- a/tff_modular/modules/borgo_modules/code/borgo_modules.dm
+++ b/tff_modular/modules/borgo_modules/code/borgo_modules.dm
@@ -10,7 +10,6 @@
 	var/image/stored_underlay
 
 /obj/item/borg/apparatus/handcuff/Initialize(mapload)
-	add_glass()
 	RegisterSignal(stored, COMSIG_ATOM_UPDATED_ICON, PROC_REF(on_stored_updated_icon))
 	update_appearance()
 	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -9785,6 +9785,7 @@
 #include "tff_modular\modules\blueshield-rearm\code\revolver.dm"
 #include "tff_modular\modules\blueshield-rearm\code\weapon_beacon.dm"
 #include "tff_modular\modules\blueshield-rearm\code\wt550.dm"
+#include "tff_modular\modules\borgo_modules\code\borgo_modules.dm"
 #include "tff_modular\modules\bunny\code\bunnydrobe.dm"
 #include "tff_modular\modules\bunny\code\cargo.dm"
 #include "tff_modular\modules\bunny\code\clothing\boots.dm"


### PR DESCRIPTION
## О Pull Request

Добавляет модуль для боргов на наручники.
Борги теперь могут иметь нормальные наручники. Борг может подобрать наручники с поверхности. Борг может взять ЛЮБЫЕ наручники. Борг НЕ может пополнять наручники в зарядной станции (Пусть пополняются как обычные СБшники в своем отделе.). Наручников только ОДНА штука. Наручники можно выбросить из руки.

Я хотел поменять спрайт держалке наручников, но я не смог ничего придумать, поэтому за основу взят спрайт держалок бикеров.

## Как это может улучшить/повлиять на игровой процесс/ролевую игру

Борги СБ и синдипука могут использовать наручники и пополнять их.

## Доказательства тестирования

Даааа........да-да.....

<details>
<summary>Скриншоты/Видео</summary>
<img width="581" height="83" alt="image" src="https://github.com/user-attachments/assets/08f772bd-f837-4a5d-b27d-aa929b2c7ba9" />
<img width="430" height="129" alt="image" src="https://github.com/user-attachments/assets/1233424e-8b87-455a-8558-2803bb745d09" />
</details>

## Changelog

:cl:
add: Боргам СБ и Синдиката добавлены новые модули наручников как альтернатива простым наручникам. В зарядниках для боргов они НЕ ПОПОЛНЯЮТСЯ.
/:cl:

