### PR TITLE
Запрягаем автолейблер

### DIFF
--- a/tools/pull_request_hooks/autoLabelConfig.js
+++ b/tools/pull_request_hooks/autoLabelConfig.js
@@ -69,7 +69,11 @@ export const title_labels = {
   },
   // FLUFFY FRONTIER ADDITION START
   "Upstream PR Batch": {
-    keywords: ["[Batch]", "Batch of Upstream PRs"],
+    keywords: ["[batch]", "batch of upstream prs"],
+	add_only: true,
+  },
+  "Manual Mirror": {
+	keywords: ["[early mirror]", "[manual mirror]", "[mirror]"],
 	add_only: true,
   },
   // FLUFFY FRONTIER ADDITION END

--- a/tools/pull_request_hooks/autoLabelConfig.js
+++ b/tools/pull_request_hooks/autoLabelConfig.js
@@ -67,6 +67,12 @@ export const title_labels = {
   "Test Merge Only": {
     keywords: ["[tm only]", "[test merge only]"],
   },
+  // FLUFFY FRONTIER ADDITION START
+  "Upstream PR Batch": {
+    keywords: ["[Batch]", "Batch of Upstream PRs"],
+	add_only: true,
+  },
+  // FLUFFY FRONTIER ADDITION END
 };
 
 // Changelog Labels


### PR DESCRIPTION

## О Pull Request

Просто добавляет автоматическую установку двух лейблов: `Upstream PR Batch` и `Manual Mirror`.
Первый если в названии есть `[batch]` или `batch of upstream prs`.
Второй если в названии есть `[early mirror]`, `[manual mirror]` или `[mirror]`.

Ну а то зачем я его фиксил прошлым летом, а он ничего нашего не ставит(
## Доказательства тестирования
Ну...

## Changelog
Ничего, что относилось бы к игрокам
